### PR TITLE
fix: any matcher without value

### DIFF
--- a/packages/mocktail/lib/src/mocktail.dart
+++ b/packages/mocktail/lib/src/mocktail.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:matcher/matcher.dart';
 
 /// {@template mocktail_failure}
@@ -608,9 +610,11 @@ bool _listEquals<T>(List<T>? a, List<T>? b) {
   if (a == null) return b == null;
   if (b == null) return false;
   if (identical(a, b)) return true;
-  if (a.length != b.length) return false;
-  for (var index = 0; index < a.length; index += 1) {
-    if (!_isMatch(a[index], b[index])) return false;
+  final length = max(a.length, b.length);
+  for (var index = 0; index < length; index++) {
+    final ai = index < a.length ? a[index] : null;
+    final bi = index < b.length ? b[index] : null;
+    if (!_isMatch(ai, bi)) return false;
   }
   return true;
 }
@@ -619,9 +623,8 @@ bool _mapEquals<T, U>(Map<T, U>? a, Map<T, U>? b) {
   if (a == null) return b == null;
   if (b == null) return false;
   if (identical(a, b)) return true;
-  if (a.length != b.length) return false;
-  for (final key in a.keys) {
-    if (!b.containsKey(key)) return false;
+  final keys = Set<T>.from(a.keys)..addAll(b.keys);
+  for (final key in keys) {
     if (!_isMatch(a[key], b[key])) return false;
   }
   return true;

--- a/packages/mocktail/lib/src/mocktail.dart
+++ b/packages/mocktail/lib/src/mocktail.dart
@@ -623,7 +623,7 @@ bool _mapEquals<T, U>(Map<T, U>? a, Map<T, U>? b) {
   if (a == null) return b == null;
   if (b == null) return false;
   if (identical(a, b)) return true;
-  final keys = Set<T>.from(a.keys)..addAll(b.keys);
+  final keys = <T>{...a.keys, ...b.keys};
   for (final key in keys) {
     if (!_isMatch(a[key], b[key])) return false;
   }

--- a/packages/mocktail/lib/src/mocktail.dart
+++ b/packages/mocktail/lib/src/mocktail.dart
@@ -608,8 +608,6 @@ bool _listEquals<T>(List<T>? a, List<T>? b) {
   if (a == null) return b == null;
   if (b == null) return false;
   if (identical(a, b)) return true;
-  a = List.of(a)..removeWhere((e) => e == null);
-  b = List.of(b)..removeWhere((b) => b == null);
   if (a.length != b.length) return false;
   for (var index = 0; index < a.length; index += 1) {
     if (!_isMatch(a[index], b[index])) return false;
@@ -621,8 +619,6 @@ bool _mapEquals<T, U>(Map<T, U>? a, Map<T, U>? b) {
   if (a == null) return b == null;
   if (b == null) return false;
   if (identical(a, b)) return true;
-  a = Map.of(a)..removeWhere((key, value) => value == null);
-  b = Map.of(b)..removeWhere((key, value) => value == null);
   if (a.length != b.length) return false;
   for (final key in a.keys) {
     if (!b.containsKey(key)) return false;

--- a/packages/mocktail/test/mocktail_test.dart
+++ b/packages/mocktail/test/mocktail_test.dart
@@ -519,6 +519,14 @@ void main() {
           .withArgs(positional: [10]).once();
     });
 
+    test('when voidWithOptionalPositionalArg (any matcher without value)', () {
+      when(foo)
+          .calls(#voidWithOptionalPositionalArg)
+          .withArgs(positional: [any]).thenReturn();
+      expect(() => foo.voidWithOptionalPositionalArg(), returnsNormally);
+      verify(foo).called(#voidWithOptionalPositionalArg).once();
+    });
+
     test('when voidWithOptionalNamedArg (default)', () {
       when(foo).calls(#voidWithOptionalNamedArg).thenReturn();
       expect(() => foo.voidWithOptionalNamedArg(), returnsNormally);
@@ -532,6 +540,14 @@ void main() {
       verify(foo)
           .called(#voidWithOptionalNamedArg)
           .withArgs(named: {#x: 10}).once();
+    });
+
+    test('when voidWithOptionalNamedArg (any matcher without value)', () {
+      when(foo)
+          .calls(#voidWithOptionalNamedArg)
+          .withArgs(named: {#x: any}).thenReturn();
+      expect(() => foo.voidWithOptionalNamedArg(), returnsNormally);
+      verify(foo).called(#voidWithOptionalNamedArg).once();
     });
 
     test('when voidWithDefaultPositionalArg (default)', () {


### PR DESCRIPTION

## Status

**READY**

## Breaking Changes

NO

## Description

Strict invocation is currently failing if the value is `null` (e.g. `withArgs(positional: [foo], named: {#bar: any})` doesn't match `object.method(foo)`). This PR attempts to fix that.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
