### PR TITLE
Removed the `of` parameter of matchers in exchange for a `registerFallbackValue`

### DIFF
--- a/packages/mocktail/lib/src/_register_matcher.dart
+++ b/packages/mocktail/lib/src/_register_matcher.dart
@@ -1,22 +1,79 @@
 part of 'mocktail.dart';
 
+Type _typeof<T>() => T;
+
+Map<Type, Object?> _createInitialFallbackValues() {
+  final result = <Type, Object?>{};
+
+  void createValue<T>(T value) {
+    result[T] = value;
+  }
+
+  createValue<bool>(false);
+  createValue<int>(42);
+  createValue<double>(42);
+  createValue<num>(42);
+  createValue<String>('42');
+  createValue<Object>('42');
+  createValue<dynamic>('42');
+  createValue<Map<String, dynamic>>(const <String, dynamic>{});
+  createValue<Map<String, Object>>(const <String, Object>{});
+  createValue<Map<String, Object>>(const <String, Object>{});
+  createValue<Map<String?, dynamic>>(const <String, dynamic>{});
+  createValue<Map<String?, Object>>(const <String, Object>{});
+  createValue<Map<String?, Object?>>(const <String, Object>{});
+  createValue<List<int>>(const <int>[]);
+  createValue<List<int?>>(const <int>[]);
+  createValue<List<double>>(const <double>[]);
+  createValue<List<double?>>(const <double?>[]);
+  createValue<List<num>>(const <num>[]);
+  createValue<List<num?>>(const <num?>[]);
+  createValue<List<String>>(const <String>[]);
+  createValue<List<String?>>(const <String?>[]);
+  createValue<List<Object>>(const <Object>[]);
+  createValue<List<Object?>>(const <Object?>[]);
+  createValue<List<bool>>(const <bool>[]);
+  createValue<List<bool?>>(const <bool?>[]);
+  createValue<List<dynamic>>(const <dynamic>[]);
+
+  return result;
+}
+
+var _fallbackValues = _createInitialFallbackValues();
+
+/// Allows [any] and [captureAny] to be used on parameters of type [T].
+///
+/// It is necessary for tests to call  [registerFallbackValue] before using
+/// [any]/[captureAny] because otherwise it would not be possible to assign
+/// [any]/[captureAny] as value to a non-nullable parameter.
+///
+/// Mocktail comes with already pre-registered values, for types such as [int],
+/// [String] and more.
+///
+/// Once registered, a value cannot be unregistered, even when using
+/// [resetMocktailState].
+///
+/// It is a good practice to create a function shared between all tests that
+/// calls [registerFallbackValue] with various types used in the project.
+void registerFallbackValue<T>(T value) {
+  _fallbackValues[T] = value;
+}
+
 /// An argument matcher that matches any argument passed in.
-T any<T>({required T of, String? named, Matcher? that}) {
+T any<T>({String? named, Matcher? that}) {
   return _registerMatcher(
     that ?? anything,
-    of,
-    false,
+    capture: false,
     named: named,
     argumentMatcher: named != null ? 'anyNamed' : 'any',
   );
 }
 
 /// An argument matcher that captures any argument passed in.
-T captureAny<T>({required T of, String? named, Matcher? that}) {
+T captureAny<T>({String? named, Matcher? that}) {
   return _registerMatcher(
     that ?? anything,
-    of,
-    true,
+    capture: true,
     named: named,
     argumentMatcher: named != null ? 'anyNamed' : 'any',
   );
@@ -30,9 +87,8 @@ T captureAny<T>({required T of, String? named, Matcher? that}) {
 /// [argumentMatcher] is the name of the public API used to register [matcher],
 /// for error messages.
 T _registerMatcher<T>(
-  Matcher matcher,
-  T defaultValue,
-  bool capture, {
+  Matcher matcher, {
+  required bool capture,
   String? named,
   String? argumentMatcher,
 }) {
@@ -44,10 +100,11 @@ T _registerMatcher<T>(
     _storedNamedArgs.clear();
     _numMatchers = 0;
     throw ArgumentError(
-        'The "$argumentMatcher" argument matcher is used outside of method '
-        '''stubbing (via `when`) or verification (via `verify` or `untilCalled`). '''
-        'This is invalid, and results in bad behavior during the next stubbing '
-        'or verification.');
+      'The "$argumentMatcher" argument matcher is used outside of method '
+      '''stubbing (via `when`) or verification (via `verify` or `untilCalled`). '''
+      'This is invalid, and results in bad behavior during the next stubbing '
+      'or verification.',
+    );
   }
   _numMatchers++;
   final argMatcher = ArgMatcher(matcher, capture);
@@ -56,5 +113,40 @@ T _registerMatcher<T>(
   } else {
     _storedNamedArgs[named] = argMatcher;
   }
-  return defaultValue;
+
+  if (T == _typeof<T?>()) {
+    // T is nullable, so we can safely return `null`
+    return null as T;
+  }
+
+  if (!_fallbackValues.containsKey(T)) {
+    throw StateError('''
+A test tried to use `any` or `captureAny` on a parameter of type `$T`, but
+registerFallbackValue was not previously called to register a fallback value for `$T`
+
+To fix, do:
+
+```
+void main() {
+  setupAll(() {
+    registerFallbackValue<$T>($T());
+  });
+}
+```
+
+If you cannot easily create an instance of $T, consider defining a `Fake`:
+
+```
+class ${T}Fake extends Fake implements $T {}
+
+void main() {
+  setupAll(() {
+    registerFallbackValue<$T>(${T}Fake());
+  });
+}
+```
+''');
+  }
+
+  return _fallbackValues[T] as T;
 }

--- a/packages/mocktail/test/matcher_test.dart
+++ b/packages/mocktail/test/matcher_test.dart
@@ -1,0 +1,136 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:mocktail/src/mocktail.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final mock = MyMock();
+
+  tearDown(resetMocktailState);
+
+  test('mocktail comes with pre-registered types', () {
+    when(() => mock<bool>(any())).thenReturn('OK');
+    when(() => mock<int>(any())).thenReturn('OK');
+    when(() => mock<double>(any())).thenReturn('OK');
+    when(() => mock<num>(any())).thenReturn('OK');
+    when(() => mock<String>(any())).thenReturn('OK');
+    when(() => mock<Object>(any())).thenReturn('OK');
+    when(() => mock<dynamic>(any<dynamic>())).thenReturn('OK');
+    when(() => mock<Map<String, dynamic>>(any())).thenReturn('OK');
+    when(() => mock<Map<String, Object>>(any())).thenReturn('OK');
+    when(() => mock<Map<String, Object>>(any())).thenReturn('OK');
+    when(() => mock<Map<String?, dynamic>>(any())).thenReturn('OK');
+    when(() => mock<Map<String?, Object>>(any())).thenReturn('OK');
+    when(() => mock<Map<String?, Object?>>(any())).thenReturn('OK');
+    when(() => mock<List<int>>(any())).thenReturn('OK');
+    when(() => mock<List<int?>>(any())).thenReturn('OK');
+    when(() => mock<List<double>>(any())).thenReturn('OK');
+    when(() => mock<List<double?>>(any())).thenReturn('OK');
+    when(() => mock<List<num>>(any())).thenReturn('OK');
+    when(() => mock<List<num?>>(any())).thenReturn('OK');
+    when(() => mock<List<String>>(any())).thenReturn('OK');
+    when(() => mock<List<String?>>(any())).thenReturn('OK');
+    when(() => mock<List<Object>>(any())).thenReturn('OK');
+    when(() => mock<List<Object?>>(any())).thenReturn('OK');
+    when(() => mock<List<bool>>(any())).thenReturn('OK');
+    when(() => mock<List<bool?>>(any())).thenReturn('OK');
+    when(() => mock<List<dynamic>>(any())).thenReturn('OK');
+
+    expect(mock<bool>(false), 'OK');
+    expect(mock<int>(42), 'OK');
+    expect(mock<double>(42), 'OK');
+    expect(mock<num>(42), 'OK');
+    expect(mock<String>('42'), 'OK');
+    expect(mock<Object>(42), 'OK');
+    expect(mock<dynamic>(42), 'OK');
+    expect(mock<Map<String, dynamic>>(<String, dynamic>{}), 'OK');
+    expect(mock<Map<String, Object>>({}), 'OK');
+    expect(mock<Map<String, Object>>({}), 'OK');
+    expect(mock<Map<String?, dynamic>>(<String?, dynamic>{}), 'OK');
+    expect(mock<Map<String?, Object>>({}), 'OK');
+    expect(mock<Map<String?, Object?>>({}), 'OK');
+    expect(mock<List<int>>([]), 'OK');
+    expect(mock<List<int?>>([]), 'OK');
+    expect(mock<List<double>>([]), 'OK');
+    expect(mock<List<double?>>([]), 'OK');
+    expect(mock<List<num>>([]), 'OK');
+    expect(mock<List<num?>>([]), 'OK');
+    expect(mock<List<String>>([]), 'OK');
+    expect(mock<List<String?>>([]), 'OK');
+    expect(mock<List<Object>>([]), 'OK');
+    expect(mock<List<Object?>>([]), 'OK');
+    expect(mock<List<bool>>([]), 'OK');
+    expect(mock<List<bool?>>([]), 'OK');
+    expect(mock<List<dynamic>>(<dynamic>[]), 'OK');
+  });
+
+  test(
+      'when the type is nullable, '
+      'matchers should work even if the type was not registered', () {
+    when(() => mock<ComplexObject?>(any())).thenReturn('OK');
+
+    expect(mock<ComplexObject?>(ComplexObject()), 'OK');
+  });
+
+  test('when a type is not registered, throws an error', () {
+    expect(
+      () => when(() => mock<UnregisteredObject>(any())),
+      throwsA(
+        isA<StateError>().having((e) => e.message, 'message', '''
+A test tried to use `any` or `captureAny` on a parameter of type `UnregisteredObject`, but
+registerFallbackValue was not previously called to register a fallback value for `UnregisteredObject`
+
+To fix, do:
+
+```
+void main() {
+  setupAll(() {
+    registerFallbackValue<UnregisteredObject>(UnregisteredObject());
+  });
+}
+```
+
+If you cannot easily create an instance of UnregisteredObject, consider defining a `Fake`:
+
+```
+class UnregisteredObjectFake extends Fake implements UnregisteredObject {}
+
+void main() {
+  setupAll(() {
+    registerFallbackValue<UnregisteredObject>(UnregisteredObjectFake());
+  });
+}
+```
+'''),
+      ),
+    );
+  });
+
+  test('calling registerFallbackValue allows matchers to work with this type',
+      () {
+    registerFallbackValue<ManuallyRegisteredObject>(ManuallyRegisteredObject());
+
+    when(() => mock<ManuallyRegisteredObject>(any())).thenReturn('OK');
+
+    expect(mock<ManuallyRegisteredObject>(ManuallyRegisteredObject()), 'OK');
+  });
+
+  test('registered types are preserved accross reset', () {
+    registerFallbackValue<ManuallyRegisteredObject>(ManuallyRegisteredObject());
+
+    resetMocktailState();
+
+    when(() => mock<ManuallyRegisteredObject>(any())).thenReturn('OK');
+
+    expect(mock<ManuallyRegisteredObject>(ManuallyRegisteredObject()), 'OK');
+  });
+}
+
+class MyMock extends Mock {
+  String call<T>(T value);
+}
+
+class ComplexObject {}
+
+class ManuallyRegisteredObject {}
+
+class UnregisteredObject {}

--- a/packages/mocktail/test/mockito_compat/generated_mocks_test.dart
+++ b/packages/mocktail/test/mockito_compat/generated_mocks_test.dart
@@ -72,7 +72,7 @@ void main() {
     test(
         'a method with a non-nullable positional parameter accepts an argument '
         'matcher while stubbing', () {
-      when(() => foo.positionalParameter(any(of: 0))).thenReturn('Stubbed');
+      when(() => foo.positionalParameter(any())).thenReturn('Stubbed');
       expect(foo.positionalParameter(42), equals('Stubbed'));
     });
 
@@ -80,7 +80,7 @@ void main() {
         'a method with a non-nullable named parameter accepts an argument '
         'matcher while stubbing', () {
       when(
-        () => foo.namedParameter(x: any(of: 0, named: 'x')),
+        () => foo.namedParameter(x: any(named: 'x')),
       ).thenReturn('Stubbed');
       expect(foo.namedParameter(x: 42), equals('Stubbed'));
     });
@@ -88,19 +88,19 @@ void main() {
     test(
         'a method with a non-nullable parameter accepts an argument matcher '
         'while verifying', () {
-      when(() => foo.positionalParameter(any(of: 0))).thenReturn('Stubbed');
+      when(() => foo.positionalParameter(any())).thenReturn('Stubbed');
       foo.positionalParameter(42);
       expect(
-        () => verify(() => foo.positionalParameter(any(of: 0))),
+        () => verify(() => foo.positionalParameter(any())),
         returnsNormally,
       );
     });
 
     test('a method with a non-nullable parameter can capture an argument', () {
-      when(() => foo.positionalParameter(any(of: 0))).thenReturn('Stubbed');
+      when(() => foo.positionalParameter(any())).thenReturn('Stubbed');
       foo.positionalParameter(42);
       final captured = verify(
-        () => foo.positionalParameter(captureAny(of: 0)),
+        () => foo.positionalParameter(captureAny()),
       ).captured;
       expect(captured[0], equals(42));
     });

--- a/packages/mocktail/test/mockito_compat/mockito_test.dart
+++ b/packages/mocktail/test/mockito_compat/mockito_test.dart
@@ -1,4 +1,5 @@
 import 'package:mocktail/mocktail.dart';
+import 'package:mocktail/src/mocktail.dart';
 import 'package:test/test.dart';
 
 class _RealClass {
@@ -50,6 +51,10 @@ void expectFail(String expectedMessage, void Function() expectedToFail) {
 
 void main() {
   late _MockedClass mock;
+
+  setUpAll(() {
+    registerFallbackValue<_RealClass>(_RealClass());
+  });
 
   setUp(() {
     mock = _MockedClass();
@@ -108,7 +113,9 @@ void main() {
     test('should mock method with argument matcher', () {
       when(
         () => mock.methodWithNormalArgs(
-          any(that: greaterThan(100), of: null),
+          any(
+            that: greaterThan(100),
+          ),
         ),
       ).thenReturn('A lot!');
       expect(mock.methodWithNormalArgs(100), isNull);
@@ -116,14 +123,13 @@ void main() {
     });
 
     test('should mock method with any argument matcher', () {
-      when(() => mock.methodWithNormalArgs(any(of: 0))).thenReturn('A lot!');
+      when(() => mock.methodWithNormalArgs(any())).thenReturn('A lot!');
       expect(mock.methodWithNormalArgs(100), equals('A lot!'));
       expect(mock.methodWithNormalArgs(101), equals('A lot!'));
     });
 
     test('should mock method with any list argument matcher', () {
-      List<int?>? list;
-      when(() => mock.methodWithListArgs(any(of: list))).thenReturn('A lot!');
+      when(() => mock.methodWithListArgs(any())).thenReturn('A lot!');
       expect(mock.methodWithListArgs([42]), equals('A lot!'));
       expect(mock.methodWithListArgs([43]), equals('A lot!'));
     });
@@ -131,14 +137,14 @@ void main() {
     test('should mock method with multiple named args and matchers', () {
       when(
         () => mock.methodWithTwoNamedArgs(
-          any(of: 0),
-          y: any(of: 0, named: 'y'),
+          any(),
+          y: any(named: 'y'),
         ),
       ).thenReturn('x y');
       when(
         () => mock.methodWithTwoNamedArgs(
-          any(of: 0),
-          z: any(of: 0, named: 'z'),
+          any(),
+          z: any(named: 'z'),
         ),
       ).thenReturn('x z');
       expect(mock.methodWithTwoNamedArgs(42), 'x z');
@@ -147,9 +153,9 @@ void main() {
       expect(mock.methodWithTwoNamedArgs(42, y: 18, z: 17), isNull);
       when(
         () => mock.methodWithTwoNamedArgs(
-          any(of: 0),
-          y: any(of: 0, named: 'y'),
-          z: any(of: 0, named: 'z'),
+          any(),
+          y: any(named: 'y'),
+          z: any(named: 'z'),
         ),
       ).thenReturn('x y z');
       expect(mock.methodWithTwoNamedArgs(42, y: 18, z: 17), equals('x y z'));
@@ -159,7 +165,9 @@ void main() {
         () {
       when(
         () => mock.methodWithPositionalArgs(
-          any(that: greaterThan(100), of: 0),
+          any(
+            that: greaterThan(100),
+          ),
           17,
         ),
       ).thenReturn('A lot with 17');
@@ -188,13 +196,12 @@ void main() {
     });
 
     test('should mock method with thrown result', () {
-      when(() => mock.methodWithNormalArgs(any(of: 0)))
-          .thenThrow(StateError('Boo'));
+      when(() => mock.methodWithNormalArgs(any())).thenThrow(StateError('Boo'));
       expect(() => mock.methodWithNormalArgs(42), throwsStateError);
     });
 
     test('should mock method with calculated result', () {
-      when(() => mock.methodWithNormalArgs(any(of: 0))).thenAnswer(
+      when(() => mock.methodWithNormalArgs(any())).thenAnswer(
           (Invocation inv) => inv.positionalArguments[0].toString());
       expect(mock.methodWithNormalArgs(43), equals('43'));
       expect(mock.methodWithNormalArgs(42), equals('42'));
@@ -213,10 +220,12 @@ void main() {
     });
 
     test('should mock method with calculated result', () {
-      when(() => mock.methodWithNormalArgs(any(that: equals(43), of: null)))
-          .thenReturn('43');
-      when(() => mock.methodWithNormalArgs(any(that: equals(42), of: null)))
-          .thenReturn('42');
+      when(() => mock.methodWithNormalArgs(any(
+            that: equals(43),
+          ))).thenReturn('43');
+      when(() => mock.methodWithNormalArgs(any(
+            that: equals(42),
+          ))).thenReturn('42');
       expect(mock.methodWithNormalArgs(43), equals('43'));
     });
 
@@ -267,7 +276,7 @@ void main() {
       expect(
         () {
           when(
-            () => mock.methodWithNamedArgs(42, y: any(of: 0, named: 'z')),
+            () => mock.methodWithNamedArgs(42, y: any(named: 'z')),
           ).thenReturn('99');
         },
         throwsArgumentError,
@@ -307,15 +316,5 @@ void main() {
       when(() => mock.methodWithNormalArgs(42)).thenReturn('Ultimate Answer');
       expect(() => mock.methodWithoutArgs(), throwsException);
     });
-  });
-
-  test(
-      'reports an error when using an argument matcher outside of stubbing or '
-      'verification', () {
-    int? type;
-    expect(
-      () => mock.methodWithNormalArgs(any(of: type)),
-      throwsArgumentError,
-    );
   });
 }

--- a/packages/mocktail/test/mockito_compat/until_called_test.dart
+++ b/packages/mocktail/test/mockito_compat/until_called_test.dart
@@ -78,67 +78,71 @@ void main() {
       test('waits for method with normal args', () async {
         mock.methodWithNormalArgs(1);
 
-        await untilCalled(() => mock.methodWithNormalArgs(any(of: null)));
+        await untilCalled(() => mock.methodWithNormalArgs(any()));
 
-        verify(() => mock.methodWithNormalArgs(any(of: null))).called(1);
+        verify(() => mock.methodWithNormalArgs(any())).called(1);
       });
 
       test('waits for method with list args', () async {
         mock.methodWithListArgs([1]);
 
-        await untilCalled(() => mock.methodWithListArgs(any(of: null)));
+        await untilCalled(() => mock.methodWithListArgs(any()));
 
-        verify(() => mock.methodWithListArgs(any(of: null))).called(1);
+        verify(() => mock.methodWithListArgs(any())).called(1);
       });
 
       test('waits for method with positional args', () async {
         mock.methodWithPositionalArgs(1, 2);
 
-        await untilCalled(
-            () => mock.methodWithPositionalArgs(any(of: null), any(of: null)));
+        await untilCalled(() => mock.methodWithPositionalArgs(any(), any()));
 
-        verify(() =>
-                mock.methodWithPositionalArgs(any(of: null), any(of: null)))
-            .called(1);
+        verify(() => mock.methodWithPositionalArgs(any(), any())).called(1);
       });
 
       test('waits for method with named args', () async {
         mock.methodWithNamedArgs(1, y: 2);
 
-        await untilCalled(() =>
-            mock.methodWithNamedArgs(any(of: 0), y: any(named: 'y', of: 0)));
+        await untilCalled(
+          () => mock.methodWithNamedArgs(any(), y: any(named: 'y')),
+        );
 
-        verify(() =>
-                mock.methodWithNamedArgs(any(of: 0), y: any(named: 'y', of: 0)))
+        verify(() => mock.methodWithNamedArgs(any(), y: any(named: 'y')))
             .called(1);
       });
 
       test('waits for method with two named args', () async {
         mock.methodWithTwoNamedArgs(1, y: 2, z: 3);
 
-        await untilCalled(() => mock.methodWithTwoNamedArgs(any(of: 0),
-            y: any(named: 'y', of: 0), z: any(named: 'z', of: 0)));
+        await untilCalled(
+          () => mock.methodWithTwoNamedArgs(
+            any(),
+            y: any(named: 'y'),
+            z: any(named: 'z'),
+          ),
+        );
 
-        verify(() => mock.methodWithTwoNamedArgs(any(of: 0),
-            y: any(named: 'y', of: 0), z: any(named: 'z', of: 0))).called(1);
+        verify(() => mock.methodWithTwoNamedArgs(
+              any(),
+              y: any(named: 'y'),
+              z: any(named: 'z'),
+            )).called(1);
       });
 
       test('waits for method with obj args', () async {
         mock.methodWithObjArgs(_RealClass());
 
-        await untilCalled(() => mock.methodWithObjArgs(any(of: null)));
+        await untilCalled(() => mock.methodWithObjArgs(any()));
 
-        verify(() => mock.methodWithObjArgs(any(of: null))).called(1);
+        verify(() => mock.methodWithObjArgs(any())).called(1);
       });
 
       test('waits for function with positional parameters', () async {
         mock.typeParameterizedFn([1, 2], [3, 4], [5, 6], [7, 8]);
 
-        await untilCalled(() => mock.typeParameterizedFn(
-            any(of: null), any(of: null), any(of: null), any(of: null)));
+        await untilCalled(
+            () => mock.typeParameterizedFn(any(), any(), any(), any()));
 
-        verify(() => mock.typeParameterizedFn(
-                any(of: null), any(of: null), any(of: null), any(of: null)))
+        verify(() => mock.typeParameterizedFn(any(), any(), any(), any()))
             .called(1);
       });
 
@@ -146,12 +150,18 @@ void main() {
         mock.typeParameterizedNamedFn([1, 2], [3, 4], y: [5, 6], z: [7, 8]);
 
         await untilCalled(() => mock.typeParameterizedNamedFn(
-            any(of: null), any(of: null),
-            y: any(named: 'y', of: null), z: any(named: 'z', of: null)));
+              any(),
+              any(),
+              y: any(named: 'y'),
+              z: any(named: 'z'),
+            ));
 
-        verify(() => mock.typeParameterizedNamedFn(any(of: null), any(of: null),
-            y: any(named: 'y', of: null),
-            z: any(named: 'z', of: null))).called(1);
+        verify(() => mock.typeParameterizedNamedFn(
+              any(),
+              any(),
+              y: any(named: 'y'),
+              z: any(named: 'z'),
+            )).called(1);
       });
 
       test('waits for getter', () async {
@@ -187,94 +197,106 @@ void main() {
 
       test('waits for method with normal args', () async {
         streamController.add(CallMethodsEvent());
-        verifyNever(() => mock.methodWithNormalArgs(any(of: null)));
+        verifyNever(() => mock.methodWithNormalArgs(any()));
 
-        await untilCalled(() => mock.methodWithNormalArgs(any(of: null)));
+        await untilCalled(() => mock.methodWithNormalArgs(any()));
 
-        verify(() => mock.methodWithNormalArgs(any(of: null))).called(1);
+        verify(() => mock.methodWithNormalArgs(any())).called(1);
       });
 
       test('waits for method with list args', () async {
         streamController.add(CallMethodsEvent());
-        verifyNever(() => mock.methodWithListArgs(any(of: null)));
+        verifyNever(() => mock.methodWithListArgs(any()));
 
-        await untilCalled(() => mock.methodWithListArgs(any(of: null)));
+        await untilCalled(() => mock.methodWithListArgs(any()));
 
-        verify(() => mock.methodWithListArgs(any(of: null))).called(1);
+        verify(() => mock.methodWithListArgs(any())).called(1);
       });
 
       test('waits for method with positional args', () async {
         streamController.add(CallMethodsEvent());
-        verifyNever(
-            () => mock.methodWithPositionalArgs(any(of: 0), any(of: 0)));
+        verifyNever(() => mock.methodWithPositionalArgs(any(), any()));
 
-        await untilCalled(
-            () => mock.methodWithPositionalArgs(any(of: 0), any(of: 0)));
+        await untilCalled(() => mock.methodWithPositionalArgs(any(), any()));
 
-        verify(() => mock.methodWithPositionalArgs(any(of: 0), any(of: 0)))
-            .called(1);
+        verify(() => mock.methodWithPositionalArgs(any(), any())).called(1);
       });
 
       test('waits for method with named args', () async {
         streamController.add(CallMethodsEvent());
-        verifyNever(() =>
-            mock.methodWithNamedArgs(any(of: 0), y: any(named: 'y', of: 0)));
+        verifyNever(() => mock.methodWithNamedArgs(any(), y: any(named: 'y')));
 
-        await untilCalled(() =>
-            mock.methodWithNamedArgs(any(of: 0), y: any(named: 'y', of: 0)));
+        await untilCalled(
+          () => mock.methodWithNamedArgs(any(), y: any(named: 'y')),
+        );
 
-        verify(() =>
-                mock.methodWithNamedArgs(any(of: 0), y: any(named: 'y', of: 0)))
+        verify(() => mock.methodWithNamedArgs(any(), y: any(named: 'y')))
             .called(1);
       });
 
       test('waits for method with two named args', () async {
         streamController.add(CallMethodsEvent());
-        verifyNever(() => mock.methodWithTwoNamedArgs(any(of: 0),
-            y: any(named: 'y', of: 0), z: any(named: 'z', of: 0)));
+        verifyNever(() => mock.methodWithTwoNamedArgs(
+              any(),
+              y: any(named: 'y'),
+              z: any(named: 'z'),
+            ));
 
-        await untilCalled(() => mock.methodWithTwoNamedArgs(any(of: 0),
-            y: any(named: 'y', of: 0), z: any(named: 'z', of: 0)));
+        await untilCalled(() => mock.methodWithTwoNamedArgs(
+              any(),
+              y: any(named: 'y'),
+              z: any(named: 'z'),
+            ));
 
-        verify(() => mock.methodWithTwoNamedArgs(any(of: 0),
-            y: any(named: 'y', of: 0), z: any(named: 'z', of: 0))).called(1);
+        verify(() => mock.methodWithTwoNamedArgs(
+              any(),
+              y: any(named: 'y'),
+              z: any(named: 'z'),
+            )).called(1);
       });
 
       test('waits for method with obj args', () async {
         streamController.add(CallMethodsEvent());
-        verifyNever(() => mock.methodWithObjArgs(any(of: null)));
+        verifyNever(() => mock.methodWithObjArgs(any()));
 
-        await untilCalled(() => mock.methodWithObjArgs(any(of: null)));
+        await untilCalled(() => mock.methodWithObjArgs(any()));
 
-        verify(() => mock.methodWithObjArgs(any(of: null))).called(1);
+        verify(() => mock.methodWithObjArgs(any())).called(1);
       });
 
       test('waits for function with positional parameters', () async {
         streamController.add(CallMethodsEvent());
-        verifyNever(() => mock.typeParameterizedFn(
-            any(of: null), any(of: null), any(of: null), any(of: null)));
+        verifyNever(() => mock.typeParameterizedFn(any(), any(), any(), any()));
 
-        await untilCalled(() => mock.typeParameterizedFn(
-            any(of: null), any(of: null), any(of: null), any(of: null)));
+        await untilCalled(
+            () => mock.typeParameterizedFn(any(), any(), any(), any()));
 
-        verify(() => mock.typeParameterizedFn(
-                any(of: null), any(of: null), any(of: null), any(of: null)))
+        verify(() => mock.typeParameterizedFn(any(), any(), any(), any()))
             .called(1);
       });
 
       test('waits for function with named parameters', () async {
         streamController.add(CallMethodsEvent());
         verifyNever(() => mock.typeParameterizedNamedFn(
-            any(of: null), any(of: null),
-            y: any(named: 'y', of: null), z: any(named: 'z', of: null)));
+              any(),
+              any(),
+              y: any(named: 'y'),
+              z: any(named: 'z'),
+            ));
 
         await untilCalled(() => mock.typeParameterizedNamedFn(
-            any(of: null), any(of: null),
-            y: any(named: 'y', of: null), z: any(named: 'z', of: null)));
+              any(),
+              any(),
+              y: any(named: 'y'),
+              z: any(named: 'z'),
+            ));
 
-        verify(() => mock.typeParameterizedNamedFn(any(of: null), any(of: null),
-            y: any(named: 'y', of: null),
-            z: any(named: 'z', of: null))).called(1);
+        verify(() => mock.typeParameterizedNamedFn(
+              any(),
+              any(),
+              y: any(named: 'y'),
+              z: any(named: 'z'),
+            )).called(1);
       });
 
       test('waits for getter', () async {

--- a/packages/mocktail/test/mockito_compat/verify_test.dart
+++ b/packages/mocktail/test/mockito_compat/verify_test.dart
@@ -124,18 +124,12 @@ void main() {
           '_MockedClass.methodWithNormalArgs(100)\n'
           '$noMatchingCallsFooter', () {
         verify(
-          () => mock.methodWithNormalArgs(any(
-            that: greaterThan(100),
-            of: null,
-          )),
+          () => mock.methodWithNormalArgs(any(that: greaterThan(100))),
         );
       });
       verify(
         () => mock.methodWithNormalArgs(
-          any(
-            that: greaterThanOrEqualTo(100),
-            of: null,
-          ),
+          any(that: greaterThanOrEqualTo(100)),
         ),
       );
     });
@@ -149,18 +143,20 @@ void main() {
           '$noMatchingCallsFooter', () {
         verify(
           () => mock.methodWithPositionalArgs(
-              any(that: greaterThanOrEqualTo(100), of: null), 18),
+            any(that: greaterThanOrEqualTo(100)),
+            18,
+          ),
         );
       });
       expectFail(
           'No matching calls. All calls: '
           '_MockedClass.methodWithPositionalArgs(100, 17)\n'
           '$noMatchingCallsFooter', () {
-        verify(() => mock.methodWithPositionalArgs(
-            any(that: greaterThan(100), of: null), 17));
+        verify(() =>
+            mock.methodWithPositionalArgs(any(that: greaterThan(100)), 17));
       });
       verify(() => mock.methodWithPositionalArgs(
-          any(that: greaterThanOrEqualTo(100), of: null), 17));
+          any(that: greaterThanOrEqualTo(100)), 17));
     });
 
     test('should mock getter', () {
@@ -492,9 +488,9 @@ void main() {
         ..methodWithoutArgs()
         ..methodWithNormalArgs(2);
       final captured = verifyInOrder([
-        mock.methodWithNormalArgs(captureAny(of: null)),
+        mock.methodWithNormalArgs(captureAny()),
         mock.methodWithoutArgs(),
-        mock.methodWithNormalArgs(captureAny(of: null))
+        mock.methodWithNormalArgs(captureAny())
       ]).captured;
       expect(captured, hasLength(3));
       expect(captured[0], equals([1]));

--- a/packages/mocktail/test/mocktail_test.dart
+++ b/packages/mocktail/test/mocktail_test.dart
@@ -100,7 +100,7 @@ void main() {
     });
 
     test('when asyncValueWithPositionalArg (any)', () async {
-      when(() => foo.asyncValueWithPositionalArg(any(of: 0))).thenAnswer(
+      when(() => foo.asyncValueWithPositionalArg(any())).thenAnswer(
         (_) async => 10,
       );
       expect(await foo.asyncValueWithPositionalArg(1), 10);
@@ -108,7 +108,7 @@ void main() {
     });
 
     test('when asyncValueWithPositionalArg multiple times', () async {
-      when(() => foo.asyncValueWithPositionalArg(any(of: 0))).thenAnswer(
+      when(() => foo.asyncValueWithPositionalArg(any())).thenAnswer(
         (_) async => 10,
       );
       expect(await foo.asyncValueWithPositionalArg(1), 10);
@@ -118,14 +118,15 @@ void main() {
 
     test('when asyncValueWithPositionalArg (custom matcher)', () async {
       final isEven = isA<int>().having((x) => x % 2 == 0, 'isEven', true);
-      when(() => foo.asyncValueWithPositionalArg(any(that: isEven, of: 0)))
-          .thenAnswer((_) async => 10);
+      when(() => foo.asyncValueWithPositionalArg(any(
+            that: isEven,
+          ))).thenAnswer((_) async => 10);
       expect(await foo.asyncValueWithPositionalArg(2), 10);
       verify(() => foo.asyncValueWithPositionalArg(2)).called(1);
     });
 
     test('when asyncValueWithPositionalArg (any)', () async {
-      when(() => foo.asyncValueWithPositionalArg(any(of: 0)))
+      when(() => foo.asyncValueWithPositionalArg(any()))
           .thenAnswer((_) async => 10);
       when(() => foo.asyncValueWithPositionalArg(1))
           .thenAnswer((_) async => 42);
@@ -135,21 +136,21 @@ void main() {
     });
 
     test('when asyncValueWithPositionalArgs (any)', () async {
-      when(() => foo.asyncValueWithPositionalArgs(any(of: 0), any(of: 0)))
+      when(() => foo.asyncValueWithPositionalArgs(any(), any()))
           .thenAnswer((_) async => 10);
       expect(await foo.asyncValueWithPositionalArgs(1, 2), 10);
       verify(() => foo.asyncValueWithPositionalArgs(1, 2)).called(1);
     });
 
     test('when asyncValueWithPositionalArgs (1 any matcher)', () async {
-      when(() => foo.asyncValueWithPositionalArgs(any(of: 0), 2))
+      when(() => foo.asyncValueWithPositionalArgs(any(), 2))
           .thenAnswer((_) async => 10);
       expect(await foo.asyncValueWithPositionalArgs(1, 2), 10);
       verify(() => foo.asyncValueWithPositionalArgs(1, 2)).called(1);
     });
 
     test('when asyncValueWithPositionalArgs (2 any matchers)', () async {
-      when(() => foo.asyncValueWithPositionalArgs(any(of: 0), any(of: 0)))
+      when(() => foo.asyncValueWithPositionalArgs(any(), any()))
           .thenAnswer((_) async => 10);
       expect(await foo.asyncValueWithPositionalArgs(1, 2), 10);
       verify(() => foo.asyncValueWithPositionalArgs(1, 2)).called(1);
@@ -165,7 +166,7 @@ void main() {
 
     test('when asyncValueWithNamedArg (any)', () async {
       when(
-        () => foo.asyncValueWithNamedArg(x: any(of: 0, named: 'x')),
+        () => foo.asyncValueWithNamedArg(x: any(named: 'x')),
       ).thenAnswer((_) async => 10);
       expect(await foo.asyncValueWithNamedArg(x: 1), 10);
       verify(() => foo.asyncValueWithNamedArg(x: 1)).called(1);
@@ -175,7 +176,7 @@ void main() {
       final isOdd = isA<int>().having((x) => x % 2 == 0, 'isOdd', false);
       when(
         () => foo.asyncValueWithNamedArg(
-          x: any(of: 0, that: isOdd, named: 'x'),
+          x: any(that: isOdd, named: 'x'),
         ),
       ).thenAnswer((_) async => 10);
       expect(await foo.asyncValueWithNamedArg(x: 1), 10);
@@ -196,7 +197,7 @@ void main() {
     });
 
     test('when asyncValueWithNamedArgs (1 any matchers)', () async {
-      when(() => foo.asyncValueWithNamedArgs(x: any(of: 0, named: 'x'), y: 2))
+      when(() => foo.asyncValueWithNamedArgs(x: any(named: 'x'), y: 2))
           .thenAnswer((_) async => 10);
       expect(await foo.asyncValueWithNamedArgs(x: 1, y: 2), 10);
       verify(() => foo.asyncValueWithNamedArgs(x: 1, y: 2)).called(1);
@@ -205,8 +206,8 @@ void main() {
     test('when asyncValueWithNamedArgs (2 any matchers)', () async {
       when(
         () => foo.asyncValueWithNamedArgs(
-          x: any(of: 0, named: 'x'),
-          y: any(of: 0, named: 'y'),
+          x: any(named: 'x'),
+          y: any(named: 'y'),
         ),
       ).thenAnswer((_) async => 10);
       expect(await foo.asyncValueWithNamedArgs(x: 1, y: 2), 10);
@@ -238,8 +239,9 @@ void main() {
       when(() => foo.asyncValueWithPositionalArgs(1, 2))
           .thenAnswer((_) => Future.value(10));
       expect(await foo.asyncValueWithPositionalArgs(1, 2), 10);
-      final captured = verify(() => foo.asyncValueWithPositionalArgs(
-          captureAny(of: 0), captureAny(of: 0))).captured;
+      final captured = verify(() =>
+              foo.asyncValueWithPositionalArgs(captureAny(), captureAny()))
+          .captured;
       expect(captured, equals([1, 2]));
     });
 
@@ -249,8 +251,8 @@ void main() {
       expect(await foo.asyncValueWithNamedArgs(x: 1, y: 2), 10);
       final captured = verify(
         () => foo.asyncValueWithNamedArgs(
-          x: captureAny(of: 0, named: 'x'),
-          y: captureAny(of: 0, named: 'y'),
+          x: captureAny(named: 'x'),
+          y: captureAny(named: 'y'),
         ),
       ).captured;
       expect(captured, equals([1, 2]));
@@ -262,8 +264,8 @@ void main() {
       expect(await foo.asyncValueWithNamedAndPositionalArgs(1, y: 2), 10);
       final captured = verify(
         () => foo.asyncValueWithNamedAndPositionalArgs(
-          captureAny(of: 0),
-          y: captureAny(of: 0, named: 'y'),
+          captureAny(),
+          y: captureAny(named: 'y'),
         ),
       ).captured;
       expect(captured, equals([1, 2]));
@@ -273,16 +275,16 @@ void main() {
         () async {
       when(
         () => foo.asyncValueWithNamedAndPositionalArgs(
-          any(of: 0),
-          y: any(of: 0, named: 'y'),
+          any(),
+          y: any(named: 'y'),
         ),
       ).thenAnswer((_) => Future.value(10));
       expect(await foo.asyncValueWithNamedAndPositionalArgs(1, y: 2), 10);
       expect(await foo.asyncValueWithNamedAndPositionalArgs(10, y: 42), 10);
       final captured = verify(
         () => foo.asyncValueWithNamedAndPositionalArgs(
-          captureAny(of: 0),
-          y: captureAny(of: 0, named: 'y'),
+          captureAny(),
+          y: captureAny(named: 'y'),
         ),
       ).captured;
       expect(
@@ -326,8 +328,7 @@ void main() {
     });
 
     test('when voidWithOptionalPositionalArg (default)', () {
-      when(() => foo.voidWithOptionalPositionalArg(any(of: 0)))
-          .thenReturn(null);
+      when(() => foo.voidWithOptionalPositionalArg(any())).thenReturn(null);
       expect(() => foo.voidWithOptionalPositionalArg(1), returnsNormally);
       verify(() => foo.voidWithOptionalPositionalArg(1)).called(1);
     });
@@ -415,7 +416,7 @@ void main() {
     tearDown(resetMocktailState);
 
     test('verify count strictly depends on both member name and arguments', () {
-      when(() => baz.add(any(of: ''))).thenReturn(null);
+      when(() => baz.add(any())).thenReturn(null);
 
       const arg1 = 'A';
       const arg2 = 'B';
@@ -439,7 +440,7 @@ void main() {
         'member name and arguments (multiple calls)', () {
       const arg1 = 'A';
 
-      when(() => baz.add(any(of: ''))).thenReturn(null);
+      when(() => baz.add(any())).thenReturn(null);
 
       verifyNever(() => baz.add(arg1));
 


### PR DESCRIPTION
As discussed on slack, adds a registerFallbackValue function 

## Status

READY

## Breaking Changes

YES

## Description


## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ x 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
