### PR TITLE
Add missing fallback value

### DIFF
--- a/packages/mocktail/lib/src/_register_matcher.dart
+++ b/packages/mocktail/lib/src/_register_matcher.dart
@@ -6,6 +6,7 @@ Map<Type, Object?> _createInitialFallbackValues() {
   final result = <Type, Object?>{};
 
   void createValue<T>(T value) {
+    assert(!result.containsKey(T));
     result[T] = value;
   }
 
@@ -18,7 +19,7 @@ Map<Type, Object?> _createInitialFallbackValues() {
   createValue<dynamic>('42');
   createValue<Map<String, dynamic>>(const <String, dynamic>{});
   createValue<Map<String, Object>>(const <String, Object>{});
-  createValue<Map<String, Object>>(const <String, Object>{});
+  createValue<Map<String, Object?>>(const <String, Object?>{});
   createValue<Map<String?, dynamic>>(const <String, dynamic>{});
   createValue<Map<String?, Object>>(const <String, Object>{});
   createValue<Map<String?, Object?>>(const <String, Object>{});

--- a/packages/mocktail/test/matcher_test.dart
+++ b/packages/mocktail/test/matcher_test.dart
@@ -56,7 +56,7 @@ void main() {
     expect(mock<dynamic>(42), 'OK');
     expect(mock<Map<String, dynamic>>(<String, dynamic>{}), 'OK');
     expect(mock<Map<String, Object>>({}), 'OK');
-    expect(mock<Map<String, Object>>({}), 'OK');
+    expect(mock<Map<String, Object?>>({}), 'OK');
     expect(mock<Map<String?, dynamic>>(<String?, dynamic>{}), 'OK');
     expect(mock<Map<String?, Object>>({}), 'OK');
     expect(mock<Map<String?, Object?>>({}), 'OK');

--- a/packages/mocktail/test/matcher_test.dart
+++ b/packages/mocktail/test/matcher_test.dart
@@ -16,7 +16,7 @@ void main() {
     when(() => mock<dynamic>(any<dynamic>())).thenReturn('OK');
     when(() => mock<Map<String, dynamic>>(any())).thenReturn('OK');
     when(() => mock<Map<String, Object>>(any())).thenReturn('OK');
-    when(() => mock<Map<String, Object>>(any())).thenReturn('OK');
+    when(() => mock<Map<String, Object?>>(any())).thenReturn('OK');
     when(() => mock<Map<String?, dynamic>>(any())).thenReturn('OK');
     when(() => mock<Map<String?, Object>>(any())).thenReturn('OK');
     when(() => mock<Map<String?, Object?>>(any())).thenReturn('OK');


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
A fallback value for `Map<String, Object?>` was missing, probably because of an oversight as a fallback for `Map<String, Object>` was registered twice. I also added an assertion to check that `_createInitialFallbackValues` doesn't create a fallback twice for the same type.
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
