### PR TITLE
feat(mocktail): Generic Fallbacks

### DIFF
--- a/packages/mocktail/lib/src/_register_matcher.dart
+++ b/packages/mocktail/lib/src/_register_matcher.dart
@@ -16,47 +16,61 @@ Map<Type, Object?> _createInitialFallbackValues() {
   createValue<String>('42');
   createValue<Object>('42');
   createValue<dynamic>('42');
-  createValue<Map<String, dynamic>>(const <String, dynamic>{});
-  createValue<Map<String, Object>>(const <String, Object>{});
-  createValue<Map<String, Object>>(const <String, Object>{});
-  createValue<Map<String?, dynamic>>(const <String, dynamic>{});
-  createValue<Map<String?, Object>>(const <String, Object>{});
-  createValue<Map<String?, Object?>>(const <String, Object>{});
-  createValue<Set<int>>(const <int>{});
-  createValue<Set<int?>>(const <int?>{});
-  createValue<Set<double>>(const <double>{});
-  createValue<Set<double?>>(const <double?>{});
-  createValue<Set<num>>(const <num>{});
-  createValue<Set<num?>>(const <num?>{});
-  createValue<Set<String>>(const <String>{});
-  createValue<Set<String?>>(const <String?>{});
-  createValue<Set<bool>>(const <bool>{});
-  createValue<Set<bool?>>(const <bool?>{});
-  createValue<Set<Object>>(const <Object>{});
-  createValue<Set<Object?>>(const <Object?>{});
-  createValue<Set<dynamic>>(const <dynamic>{});
-  createValue<List<int>>(const <int>[]);
-  createValue<List<int?>>(const <int>[]);
-  createValue<List<double>>(const <double>[]);
-  createValue<List<double?>>(const <double?>[]);
-  createValue<List<num>>(const <num>[]);
-  createValue<List<num?>>(const <num?>[]);
-  createValue<List<String>>(const <String>[]);
-  createValue<List<String?>>(const <String?>[]);
-  createValue<List<Object>>(const <Object>[]);
-  createValue<List<Object?>>(const <Object?>[]);
-  createValue<List<bool>>(const <bool>[]);
-  createValue<List<bool?>>(const <bool?>[]);
-  createValue<List<dynamic>>(const <dynamic>[]);
 
   return result;
 }
 
+List<Object?> _genericFallbackValues = [
+  const <Never>[],
+  const <Never, Never>{},
+  const <Never>{},
+];
+
 final _fallbackValues = _createInitialFallbackValues();
 
+T _getFallbackValue<T>() {
+  final value = _fallbackValues[T] ??
+      _genericFallbackValues.firstWhereOrNull((element) => element is T);
+  if (value is! T) {
+    throw StateError('''
+A test tried to use `any` or `captureAny` on a parameter of type `$T`, but
+registerFallbackValue was not previously called to register a fallback value for `$T`
+
+To fix, do:
+
+```
+void main() {
+  setUpAll(() {
+    registerFallbackValue<$T>($T());
+  });
+}
+```
+
+If you cannot easily create an instance of $T, consider defining a `Fake`:
+
+```
+class ${T}Fake extends Fake implements $T {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue<$T>(${T}Fake());
+  });
+}
+```
+''');
+  }
+  return value;
+}
+
 /// Allows [any] and [captureAny] to be used on parameters of type [T].
+/// 
+/// If [matchExactType] is set to true the fallback is only used for parameters 
+/// of exact type [T]. Otherwise it is used wherever possible.
+/// Fallbacks registered with [matchExactType] set to true always take
+/// precedence. Then, the first possible value registered with [matchExactType]
+/// set to false is used.
 ///
-/// It is necessary for tests to call  [registerFallbackValue] before using
+///  It is necessary for tests to call  [registerFallbackValue] before using
 /// [any]/[captureAny] because otherwise it would not be possible to assign
 /// [any]/[captureAny] as value to a non-nullable parameter.
 ///
@@ -68,8 +82,12 @@ final _fallbackValues = _createInitialFallbackValues();
 ///
 /// It is a good practice to create a function shared between all tests that
 /// calls [registerFallbackValue] with various types used in the project.
-void registerFallbackValue<T>(T value) {
-  _fallbackValues[T] = value;
+void registerFallbackValue<T>(T value, {bool matchExactType = false}) {
+  if (matchExactType) {
+    _fallbackValues[T] = value;
+  } else {
+    _genericFallbackValues.add(value);
+  }
 }
 
 /// An argument matcher that matches any argument passed in.
@@ -130,36 +148,7 @@ T _registerMatcher<T>(
     return null as T;
   }
 
-  if (!_fallbackValues.containsKey(T)) {
-    throw StateError('''
-A test tried to use `any` or `captureAny` on a parameter of type `$T`, but
-registerFallbackValue was not previously called to register a fallback value for `$T`
-
-To fix, do:
-
-```
-void main() {
-  setUpAll(() {
-    registerFallbackValue<$T>($T());
-  });
-}
-```
-
-If you cannot easily create an instance of $T, consider defining a `Fake`:
-
-```
-class ${T}Fake extends Fake implements $T {}
-
-void main() {
-  setUpAll(() {
-    registerFallbackValue<$T>(${T}Fake());
-  });
-}
-```
-''');
-  }
-
-  final fallbackValue = _fallbackValues[T] as T;
+  final fallbackValue = _getFallbackValue<T>();
   final argMatcher = ArgMatcher(matcher, fallbackValue, capture);
   if (named == null) {
     _storedArgs.add(argMatcher);

--- a/packages/mocktail/lib/src/_register_matcher.dart
+++ b/packages/mocktail/lib/src/_register_matcher.dart
@@ -2,25 +2,6 @@ part of 'mocktail.dart';
 
 Type _typeof<T>() => T;
 
-Map<Type, Object?> _createInitialFallbackValues() {
-  final result = <Type, Object?>{};
-
-  void createValue<T>(T value) {
-    assert(!result.containsKey(T));
-    result[T] = value;
-  }
-
-  createValue<bool>(false);
-  createValue<int>(42);
-  createValue<double>(42);
-  createValue<num>(42);
-  createValue<String>('42');
-  createValue<Object>('42');
-  createValue<dynamic>('42');
-
-  return result;
-}
-
 Never _fallbackCallback([
   Object? a1,
   Object? a2,
@@ -50,18 +31,19 @@ This dummy callback is only meant to be passed around, but never called.''',
   );
 }
 
-List<Object?> _genericFallbackValues = [
+List<Object?> _fallbackValues = [
+  false,
+  42,
+  42.0,
+  '42',
   const <Never>[],
   const <Never, Never>{},
   const <Never>{},
   _fallbackCallback,
 ];
 
-final _fallbackValues = _createInitialFallbackValues();
-
 T _getFallbackValue<T>() {
-  final value = _fallbackValues[T] ??
-      _genericFallbackValues.firstWhereOrNull((element) => element is T);
+  final value = _fallbackValues.firstWhereOrNull((element) => element is T);
   if (value is! T) {
     throw StateError('''
 A test tried to use `any` or `captureAny` on a parameter of type `$T`, but
@@ -102,13 +84,7 @@ providing a convenient syntax.
 
 /// Allows [any] and [captureAny] to be used on parameters of type [T].
 ///
-/// If [matchExactType] is set to true the fallback is only used for parameters
-/// of exact type [T]. Otherwise it is used wherever possible.
-/// Fallbacks registered with [matchExactType] set to true always take
-/// precedence. Then, the first possible value registered with [matchExactType]
-/// set to false is used.
-///
-/// It is necessary for tests to call  [registerFallbackValue] before using
+/// It is necessary for tests to call [registerFallbackValue] before using
 /// [any]/[captureAny] because otherwise it would not be possible to assign
 /// [any]/[captureAny] as value to a non-nullable parameter.
 ///
@@ -120,12 +96,8 @@ providing a convenient syntax.
 ///
 /// It is a good practice to create a function shared between all tests that
 /// calls [registerFallbackValue] with various types used in the project.
-void registerFallbackValue<T>(T value, {bool matchExactType = false}) {
-  if (matchExactType) {
-    _fallbackValues[T] = value;
-  } else {
-    _genericFallbackValues.add(value);
-  }
+void registerFallbackValue<T>(T value) {
+  _fallbackValues.add(value);
 }
 
 /// An argument matcher that matches any argument passed in.

--- a/packages/mocktail/lib/src/_register_matcher.dart
+++ b/packages/mocktail/lib/src/_register_matcher.dart
@@ -63,8 +63,8 @@ void main() {
 }
 
 /// Allows [any] and [captureAny] to be used on parameters of type [T].
-/// 
-/// If [matchExactType] is set to true the fallback is only used for parameters 
+///
+/// If [matchExactType] is set to true the fallback is only used for parameters
 /// of exact type [T]. Otherwise it is used wherever possible.
 /// Fallbacks registered with [matchExactType] set to true always take
 /// precedence. Then, the first possible value registered with [matchExactType]

--- a/packages/mocktail/lib/src/_register_matcher.dart
+++ b/packages/mocktail/lib/src/_register_matcher.dart
@@ -20,19 +20,69 @@ Map<Type, Object?> _createInitialFallbackValues() {
   return result;
 }
 
+Never _fallbackCallback([
+  Object? a1,
+  Object? a2,
+  Object? a3,
+  Object? a4,
+  Object? a5,
+  Object? a6,
+  Object? a7,
+  Object? a8,
+  Object? a9,
+  Object? a10,
+  Object? a11,
+  Object? a12,
+  Object? a13,
+  Object? a14,
+  Object? a15,
+  Object? a16,
+  Object? a17,
+  Object? a18,
+  Object? a19,
+  Object? a20,
+]) {
+  throw UnsupportedError(
+    '''
+A test tried to call mockito\'s internal dummy callback.
+This dummy callback is only meant to be passed around, but never called.''',
+  );
+}
+
 List<Object?> _genericFallbackValues = [
   const <Never>[],
   const <Never, Never>{},
   const <Never>{},
+  _fallbackCallback,
 ];
 
 final _fallbackValues = _createInitialFallbackValues();
 
 T _getFallbackValue<T>() {
+  bool isFunction<T>() {
+    return T.toString().contains('=>');
+  }
+
   final value = _fallbackValues[T] ??
       _genericFallbackValues.firstWhereOrNull((element) => element is T);
   if (value is! T) {
-    throw StateError('''
+    if (isFunction<T>()) {
+      throw StateError('''
+A test tried to use `any` or `captureAny` on a parameter of type `$T`, but
+registerFallbackValue was not previously called to register a fallback value for `$T`
+
+To fix, do:
+
+```
+void main() {
+  setUpAll(() {
+    registerFallbackValue(([your callback's argument list]) => throw Error());
+  });
+}
+```
+''');
+    } else {
+      throw StateError('''
 A test tried to use `any` or `captureAny` on a parameter of type `$T`, but
 registerFallbackValue was not previously called to register a fallback value for `$T`
 
@@ -58,6 +108,7 @@ void main() {
 }
 ```
 ''');
+    }
   }
   return value;
 }

--- a/packages/mocktail/lib/src/_register_matcher.dart
+++ b/packages/mocktail/lib/src/_register_matcher.dart
@@ -44,7 +44,7 @@ Never _fallbackCallback([
 ]) {
   throw UnsupportedError(
     '''
-A test tried to call mockito\'s internal dummy callback.
+A test tried to call mocktail\'s internal dummy callback.
 This dummy callback is only meant to be passed around, but never called.''',
   );
 }

--- a/packages/mocktail/lib/src/_register_matcher.dart
+++ b/packages/mocktail/lib/src/_register_matcher.dart
@@ -70,7 +70,7 @@ void main() {
 /// precedence. Then, the first possible value registered with [matchExactType]
 /// set to false is used.
 ///
-///  It is necessary for tests to call  [registerFallbackValue] before using
+/// It is necessary for tests to call  [registerFallbackValue] before using
 /// [any]/[captureAny] because otherwise it would not be possible to assign
 /// [any]/[captureAny] as value to a non-nullable parameter.
 ///

--- a/packages/mocktail/lib/src/_register_matcher.dart
+++ b/packages/mocktail/lib/src/_register_matcher.dart
@@ -44,7 +44,7 @@ Never _fallbackCallback([
 ]) {
   throw UnsupportedError(
     '''
-A test tried to call mocktail\'s internal dummy callback.
+A test tried to call mocktail's internal dummy callback.
 This dummy callback is only meant to be passed around, but never called.''',
   );
 }
@@ -59,56 +59,42 @@ List<Object?> _genericFallbackValues = [
 final _fallbackValues = _createInitialFallbackValues();
 
 T _getFallbackValue<T>() {
-  bool isFunction<T>() {
-    return T.toString().contains('=>');
-  }
-
   final value = _fallbackValues[T] ??
       _genericFallbackValues.firstWhereOrNull((element) => element is T);
   if (value is! T) {
-    if (isFunction<T>()) {
-      throw StateError('''
+    throw StateError('''
 A test tried to use `any` or `captureAny` on a parameter of type `$T`, but
-registerFallbackValue was not previously called to register a fallback value for `$T`
+registerFallbackValue was not previously called to register a fallback value for `$T`.
 
 To fix, do:
 
 ```
 void main() {
   setUpAll(() {
-    registerFallbackValue(([your callback's argument list]) => throw Error());
-  });
-}
-```
-''');
-    } else {
-      throw StateError('''
-A test tried to use `any` or `captureAny` on a parameter of type `$T`, but
-registerFallbackValue was not previously called to register a fallback value for `$T`
-
-To fix, do:
-
-```
-void main() {
-  setUpAll(() {
-    registerFallbackValue<$T>($T());
+    registerFallbackValue(/* create a dummy instance of `$T` */);
   });
 }
 ```
 
-If you cannot easily create an instance of $T, consider defining a `Fake`:
+This instance of `$T` will only be passed around, but never be interacted with.
+Therefore, if `$T` is a function, it does not have to return a valid object and
+could throw unconditionally.
+If you cannot easily create an instance of `$T`, consider defining a `Fake`:
 
 ```
-class ${T}Fake extends Fake implements $T {}
+class MyTypeFake extends Fake implements MyType {}
 
 void main() {
   setUpAll(() {
-    registerFallbackValue<$T>(${T}Fake());
+    registerFallbackValue(MyTypeFake());
   });
 }
 ```
+
+Fallbacks are required because mocktail has to know of a valid `$T` to prevent
+TypeErrors from being thrown in Dart's sound null safe mode, while still
+providing a convenient syntax.
 ''');
-    }
   }
   return value;
 }

--- a/packages/mocktail/test/matcher_test.dart
+++ b/packages/mocktail/test/matcher_test.dart
@@ -115,7 +115,7 @@ void main() {
             (e) => e.message,
             'message',
             '''
-A test tried to call mocktail\'s internal dummy callback.
+A test tried to call mocktail's internal dummy callback.
 This dummy callback is only meant to be passed around, but never called.''',
           ),
         ),
@@ -131,56 +131,42 @@ This dummy callback is only meant to be passed around, but never called.''',
     expect(mock<ComplexObject?>(ComplexObject()), 'OK');
   });
 
-  test('when a function type is not registered, throws an error', () {
-    expect(
-      () => when(() => mock<UnregisteredCallback>(any())),
-      throwsA(
-        isA<StateError>().having((e) => e.message, 'message', '''
-A test tried to use `any` or `captureAny` on a parameter of type `({String foo, int n, ComplexObject obj}) => ComplexObject`, but
-registerFallbackValue was not previously called to register a fallback value for `({String foo, int n, ComplexObject obj}) => ComplexObject`
-
-To fix, do:
-
-```
-void main() {
-  setUpAll(() {
-    registerFallbackValue(([your callback's argument list]) => throw Error());
-  });
-}
-```
-'''),
-      ),
-    );
-  });
   test('when a type is not registered, throws an error', () {
     expect(
       () => when(() => mock<UnregisteredObject>(any())),
       throwsA(
         isA<StateError>().having((e) => e.message, 'message', '''
 A test tried to use `any` or `captureAny` on a parameter of type `UnregisteredObject`, but
-registerFallbackValue was not previously called to register a fallback value for `UnregisteredObject`
+registerFallbackValue was not previously called to register a fallback value for `UnregisteredObject`.
 
 To fix, do:
 
 ```
 void main() {
   setUpAll(() {
-    registerFallbackValue<UnregisteredObject>(UnregisteredObject());
+    registerFallbackValue(/* create a dummy instance of `UnregisteredObject` */);
   });
 }
 ```
 
-If you cannot easily create an instance of UnregisteredObject, consider defining a `Fake`:
+This instance of `UnregisteredObject` will only be passed around, but never be interacted with.
+Therefore, if `UnregisteredObject` is a function, it does not have to return a valid object and
+could throw unconditionally.
+If you cannot easily create an instance of `UnregisteredObject`, consider defining a `Fake`:
 
 ```
-class UnregisteredObjectFake extends Fake implements UnregisteredObject {}
+class MyTypeFake extends Fake implements MyType {}
 
 void main() {
   setUpAll(() {
-    registerFallbackValue<UnregisteredObject>(UnregisteredObjectFake());
+    registerFallbackValue(MyTypeFake());
   });
 }
 ```
+
+Fallbacks are required because mocktail has to know of a valid `UnregisteredObject` to prevent
+TypeErrors from being thrown in Dart's sound null safe mode, while still
+providing a convenient syntax.
 '''),
       ),
     );
@@ -237,36 +223,39 @@ void main() {
       expect(
         () => when(() => mock<NotAllowedSuperclass>(any())).thenReturn('OK'),
         throwsA(
-          isA<StateError>().having(
-            (e) => e.message,
-            'message',
-            '''
+          isA<StateError>().having((e) => e.message, 'message', '''
 A test tried to use `any` or `captureAny` on a parameter of type `NotAllowedSuperclass`, but
-registerFallbackValue was not previously called to register a fallback value for `NotAllowedSuperclass`
+registerFallbackValue was not previously called to register a fallback value for `NotAllowedSuperclass`.
 
 To fix, do:
 
 ```
 void main() {
   setUpAll(() {
-    registerFallbackValue<NotAllowedSuperclass>(NotAllowedSuperclass());
+    registerFallbackValue(/* create a dummy instance of `NotAllowedSuperclass` */);
   });
 }
 ```
 
-If you cannot easily create an instance of NotAllowedSuperclass, consider defining a `Fake`:
+This instance of `NotAllowedSuperclass` will only be passed around, but never be interacted with.
+Therefore, if `NotAllowedSuperclass` is a function, it does not have to return a valid object and
+could throw unconditionally.
+If you cannot easily create an instance of `NotAllowedSuperclass`, consider defining a `Fake`:
 
 ```
-class NotAllowedSuperclassFake extends Fake implements NotAllowedSuperclass {}
+class MyTypeFake extends Fake implements MyType {}
 
 void main() {
   setUpAll(() {
-    registerFallbackValue<NotAllowedSuperclass>(NotAllowedSuperclassFake());
+    registerFallbackValue(MyTypeFake());
   });
 }
 ```
-''',
-          ),
+
+Fallbacks are required because mocktail has to know of a valid `NotAllowedSuperclass` to prevent
+TypeErrors from being thrown in Dart's sound null safe mode, while still
+providing a convenient syntax.
+'''),
         ),
       );
     });

--- a/packages/mocktail/test/matcher_test.dart
+++ b/packages/mocktail/test/matcher_test.dart
@@ -202,65 +202,6 @@ providing a convenient syntax.
     });
   });
 
-  group('registerFallbackValue with matchExactType set to true', () {
-    test('allows matchers to work with this type', () {
-      registerFallbackValue<ExactlyRegisteredClass>(
-        ExactlyRegisteredClass(),
-        matchExactType: true,
-      );
-
-      when(() => mock<ExactlyRegisteredClass>(any())).thenReturn('OK');
-
-      expect(mock<ExactlyRegisteredClass>(ExactlyRegisteredClass()), 'OK');
-    });
-
-    test('does not allow matchers to work with supertypes', () {
-      registerFallbackValue<ManuallyRegisteredExactSubclass>(
-        ManuallyRegisteredExactSubclass(),
-        matchExactType: true,
-      );
-
-      expect(
-        () => when(() => mock<NotAllowedSuperclass>(any())).thenReturn('OK'),
-        throwsA(
-          isA<StateError>().having((e) => e.message, 'message', '''
-A test tried to use `any` or `captureAny` on a parameter of type `NotAllowedSuperclass`, but
-registerFallbackValue was not previously called to register a fallback value for `NotAllowedSuperclass`.
-
-To fix, do:
-
-```
-void main() {
-  setUpAll(() {
-    registerFallbackValue(/* create a dummy instance of `NotAllowedSuperclass` */);
-  });
-}
-```
-
-This instance of `NotAllowedSuperclass` will only be passed around, but never be interacted with.
-Therefore, if `NotAllowedSuperclass` is a function, it does not have to return a valid object and
-could throw unconditionally.
-If you cannot easily create an instance of `NotAllowedSuperclass`, consider defining a `Fake`:
-
-```
-class MyTypeFake extends Fake implements MyType {}
-
-void main() {
-  setUpAll(() {
-    registerFallbackValue(MyTypeFake());
-  });
-}
-```
-
-Fallbacks are required because mocktail has to know of a valid `NotAllowedSuperclass` to prevent
-TypeErrors from being thrown in Dart's sound null safe mode, while still
-providing a convenient syntax.
-'''),
-        ),
-      );
-    });
-  });
-
   test('registered types are preserved accross reset', () {
     registerFallbackValue<ManuallyRegisteredObject>(ManuallyRegisteredObject());
 

--- a/packages/mocktail/test/matcher_test.dart
+++ b/packages/mocktail/test/matcher_test.dart
@@ -115,7 +115,7 @@ void main() {
             (e) => e.message,
             'message',
             '''
-A test tried to call mockito\'s internal dummy callback.
+A test tried to call mocktail\'s internal dummy callback.
 This dummy callback is only meant to be passed around, but never called.''',
           ),
         ),

--- a/packages/mocktail/test/matcher_test.dart
+++ b/packages/mocktail/test/matcher_test.dart
@@ -20,6 +20,11 @@ void main() {
     when(() => mock<Map<String?, dynamic>>(any())).thenReturn('OK');
     when(() => mock<Map<String?, Object>>(any())).thenReturn('OK');
     when(() => mock<Map<String?, Object?>>(any())).thenReturn('OK');
+    when(() => mock<Map<ComplexObject, ComplexObject>>(any())).thenReturn('OK');
+    when(() => mock<Map<ComplexObject, ComplexObject?>>(any()))
+        .thenReturn('OK');
+    when(() => mock<Map<ComplexObject?, ComplexObject?>>(any()))
+        .thenReturn('OK');
     when(() => mock<List<int>>(any())).thenReturn('OK');
     when(() => mock<List<int?>>(any())).thenReturn('OK');
     when(() => mock<List<double>>(any())).thenReturn('OK');
@@ -33,6 +38,8 @@ void main() {
     when(() => mock<List<bool>>(any())).thenReturn('OK');
     when(() => mock<List<bool?>>(any())).thenReturn('OK');
     when(() => mock<List<dynamic>>(any())).thenReturn('OK');
+    when(() => mock<List<ComplexObject>>(any())).thenReturn('OK');
+    when(() => mock<List<ComplexObject?>>(any())).thenReturn('OK');
     when(() => mock<Set<int>>(any())).thenReturn('OK');
     when(() => mock<Set<int?>>(any())).thenReturn('OK');
     when(() => mock<Set<double>>(any())).thenReturn('OK');
@@ -46,6 +53,8 @@ void main() {
     when(() => mock<Set<bool>>(any())).thenReturn('OK');
     when(() => mock<Set<bool?>>(any())).thenReturn('OK');
     when(() => mock<Set<dynamic>>(any())).thenReturn('OK');
+    when(() => mock<Set<ComplexObject>>(any())).thenReturn('OK');
+    when(() => mock<Set<ComplexObject?>>(any())).thenReturn('OK');
 
     expect(mock<bool>(false), 'OK');
     expect(mock<int>(42), 'OK');


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->

The general idea is to use `List<Never>`, `Map<Never, Never>` and `Set<Never>` as a fallback for any list/map/set.

This patch adds fallback values as a `List`, where the first value that `is` the type we want will be chosen from as the fallback. I still left the original mechanism in and added `matchExactType` parameter to the `registerFallbackValue` function to distinguish between the mechanisms. Thoughts? Not sure if this API is the best.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
