### PR TITLE
Adding thenAnswerWithVoid

### DIFF
--- a/packages/mocktail/lib/src/mocktail.dart
+++ b/packages/mocktail/lib/src/mocktail.dart
@@ -6,10 +6,15 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 part '_arg_matcher.dart';
+
 part '_invocation_matcher.dart';
+
 part '_is_invocation.dart';
+
 part '_real_call.dart';
+
 part '_register_matcher.dart';
+
 part '_time_stamp_provider.dart';
 
 _WhenCall? _whenCall;
@@ -268,6 +273,13 @@ class When<T> {
     _whenCall = null;
     _whenInProgress = false;
   }
+}
+
+/// Extension to enable [thenAnswerWithVoid] method
+extension VoidAnswer on When<Future<void>> {
+  /// Resolves the method without any return or exceptions.
+  void thenAnswerWithVoid() =>
+      _completeWhen((invocation) => Future<void>.value());
 }
 
 class _WhenCall {

--- a/packages/mocktail/test/mocktail_test.dart
+++ b/packages/mocktail/test/mocktail_test.dart
@@ -8,6 +8,7 @@ import 'package:test/test.dart';
 class Foo {
   int get intValue => 0;
   Map<String, String> get mapValue => {'foo': 'bar'};
+  Future<void> futureVoidFunction() => Future.value();
   Future<int> asyncValue() => Future.value(1);
   Future<int> asyncValueWithPositionalArg(int x) => Future.value(x);
   Future<int> asyncValueWithPositionalArgs(int x, int y) => Future.value(x + y);
@@ -341,6 +342,11 @@ void main() {
       when(() => foo.voidFunction()).thenReturn(null);
       expect(() => foo.voidFunction(), returnsNormally);
       verify(() => foo.voidFunction()).called(1);
+    });
+
+    test('when voidFunction answers with void', () {
+      when(() => foo.futureVoidFunction()).thenAnswerWithVoid();
+      expect(() => foo.voidFunction(), returnsNormally);
     });
 
     test('when voidWithPositionalAndOptionalNamedArg (default)', () {


### PR DESCRIPTION
Added a new method to prevent weird and boring usages of the mocks on stubs, like:

`when(() => foo.futureVoidFunction()).thenAnswer((invocation) => Future.value());`

Now you can just:

`when(() => foo.futureVoidFunction()).thenAnswerWithVoid();`


## Status

**READY**

## Breaking Changes

NO

## Description

Adds a convenience method.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
