### PR TITLE
docs: Fixed misleading comment on _registerMatcher

### DIFF
--- a/packages/mocktail/lib/src/_register_matcher.dart
+++ b/packages/mocktail/lib/src/_register_matcher.dart
@@ -122,7 +122,7 @@ T captureAny<T>({String? named, Matcher? that}) {
 /// Registers [matcher] into the stored arguments collections.
 ///
 /// Creates an [ArgMatcher] with [matcher] and [capture], then if [named] is
-/// non-null, stores that into the positional stored arguments list; otherwise
+/// null, stores that into the positional stored arguments list; otherwise
 /// stores it into the named stored arguments map, keyed on [named].
 /// [argumentMatcher] is the name of the public API used to register [matcher],
 /// for error messages.


### PR DESCRIPTION
if `named` is null, arguments are stored as positional, comment previously stated `non-null` instead of `null`

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
Very minor change to the text of a comment on `_registerMatcher` but it significantly changes the meaning.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
