### PR TITLE
fix(mocktail_image_network): pass onDone callback when listening to stream

### DIFF
--- a/packages/mocktail_image_network/lib/src/mocktail_image_network.dart
+++ b/packages/mocktail_image_network/lib/src/mocktail_image_network.dart
@@ -81,8 +81,9 @@ HttpClient _createHttpClient() {
   ).thenAnswer((invocation) {
     final onData =
         invocation.positionalArguments[0] as void Function(List<int>);
+    final onDone = invocation.namedArguments[#onDone] as void Function()?;
     return Stream<List<int>>.fromIterable(<List<int>>[_transparentPixelPng])
-        .listen(onData);
+        .listen(onData, onDone: onDone);
   });
   when(() => request.headers).thenReturn(headers);
   when(request.close).thenAnswer((_) async => response);

--- a/packages/mocktail_image_network/test/mocktail_image_network_test.dart
+++ b/packages/mocktail_image_network/test/mocktail_image_network_test.dart
@@ -5,7 +5,7 @@ import 'package:mocktail_image_network/mocktail_image_network.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('mockNetworkImageFor', () {
+  group('mockNetworkImages', () {
     test(
       'should properly mock getUrl and complete without exceptions',
       () async {
@@ -27,5 +27,24 @@ void main() {
         });
       },
     );
+
+    test('should properly pass through onDone', () async {
+      await mockNetworkImages(() async {
+        final client = HttpClient()..autoUncompress = false;
+        final request = await client.getUrl(Uri.https('', ''));
+        final response = await request.close();
+        var onDoneCalled = false;
+        final onDone = () {
+          onDoneCalled = true;
+        };
+
+        response.listen((_) {}, onDone: onDone);
+
+        // Wait for all microtasks to run
+        await Future<void>.delayed(Duration.zero);
+
+        expect(onDoneCalled, isTrue);
+      });
+    });
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

I ran into an issue using `precacheImage`, which would never complete when wrapped with `mockNetworkImages`. I fixed it by passing through the `onDone` callback when listening to the image stream.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
