### PR TITLE
Added then answer void method

### DIFF
--- a/packages/mocktail/lib/src/mocktail.dart
+++ b/packages/mocktail/lib/src/mocktail.dart
@@ -216,6 +216,13 @@ When<T> Function<T>(T Function() x) get when {
   };
 }
 
+/// Set of helps to [when] class
+extension WhenExtension on When<void> {
+
+  /// Store a void function which is called when this method stub is called. 
+  void thenAnswerVoid() => _completeWhen((_) async { });
+}
+
 /// Result of [when] which enables methods to be stubbed via
 /// - [thenReturn]
 /// - [thenThrow]

--- a/packages/mocktail/test/mocktail_test.dart
+++ b/packages/mocktail/test/mocktail_test.dart
@@ -122,7 +122,7 @@ void main() {
     });
 
     test('when asyncVoid (explicit)', () async {
-      when(() => foo.asyncVoid()).thenAnswer((_) async {});
+      when(() => foo.asyncVoid()).thenAnswerVoid();
       await expectLater(foo.asyncVoid(), completes);
       verify(() => foo.asyncVoid()).called(1);
     });


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Generally, much developers has to use `when` method to return `void` value.

Thus, this PR added simple extension for `when` class to make more easy works with `void` returns values.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
