### PR TITLE
docs(mocktail): use same pattern for stubbing

### DIFF
--- a/packages/mocktail/README.md
+++ b/packages/mocktail/README.md
@@ -214,5 +214,5 @@ To address this, we must explicitly stub `sleep` like:
 
 ```dart
 final person = MockPerson();
-when(person.sleep).thenAnswer((_) async {});
+when(() => person.sleep()).thenAnswer((_) async {});
 ```


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Noticed that in last section of README.md , about the `Why am I seeing error: type 'Null' is not a subtype of type 'Future<void>'?` issue, the example stubs without adding a callback. Propose to use a callback there to avoid misunderstandings. Despite anyway it's equivalent, if the guide consistently reminds using callbacks, I think would be nice to use them in that example too.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
