### PR TITLE
feat: add a new function `registerMultipleFallbackValues()`

### DIFF
--- a/packages/mocktail/lib/src/_register_matcher.dart
+++ b/packages/mocktail/lib/src/_register_matcher.dart
@@ -99,6 +99,27 @@ providing a convenient syntax.
 /// calls [registerFallbackValue] with various types used in the project.
 void registerFallbackValue(dynamic value) => _fallbackValues.add(value);
 
+/// If there are multiple custom objects that need to be registered with
+/// [registerFallbackValue], then instead of calling [registerFallbackValue]
+/// multiple times, we can use [registerMultipleFallbackValues] allowing us to
+/// do something like
+/// ```dart
+/// setUpAll(() {
+///   registerMultipleFallbackValues([FakeObj1(), FakeObj2(), FakeObj3()]);
+/// });
+/// ```
+/// instead of
+/// ```dart
+/// setUpAll(() {
+///   registerFallbackValue(FakeObj1());
+///   registerFallbackValue(FakeObj2());
+///   registerFallbackValue(FakeObj3());
+/// });
+/// ```
+void registerMultipleFallbackValues(List<dynamic> values) {
+  for (final value in values) registerFallbackValue(value);
+}
+
 /// An argument matcher that matches any argument passed in.
 T any<T>({String? named, Matcher? that}) {
   return _registerMatcher(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
So, as I was writing some unit tests, I found myself calling `registerFallbackValue()` multiple times in my `setUpAll()`. So, this PR tries to make it easier if developers need to register multiple objects with `registerFallbackValue()` by introducing `registerMultipleFallbackValues()`.
Instead of
```dart
setUpAll(() {
  registerFallbackValue(FakeObj1());
  registerFallbackValue(FakeObj2());
  registerFallbackValue(FakeObj3());
});
```
In my opinion, it is easier to do
```dart
setUpAll(() {
  registerMultipleFallbackValues([FakeObj1(), FakeObj2(), FakeObj3()]);
});
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
