### PR TITLE
Use debugNetworkImageHttpClientProvider and clear cache

### DIFF
--- a/packages/mocktail_image_network/example/lib/main.dart
+++ b/packages/mocktail_image_network/example/lib/main.dart
@@ -8,10 +8,23 @@ class FakeApp extends StatelessWidget {
       home: Scaffold(
         body: Center(
           child: Image.network(
-            'https://uploads-ssl.webflow.com/5ee12d8d7f840543bde883de/5eec278f49a4916759d679aa_vgv-wordmark-black.svg',
+            kImageUrl,
+            errorBuilder: (
+              context,
+              error,
+              stackTrace,
+            ) {
+              return const Text(kErrorText);
+            },
           ),
         ),
       ),
     );
   }
 }
+
+/// public image url for testing
+const kImageUrl = 'https://randmom-uri.com';
+
+/// public error text for testing
+const kErrorText = 'You are Doomed!';

--- a/packages/mocktail_image_network/example/test/image_test.dart
+++ b/packages/mocktail_image_network/example/test/image_test.dart
@@ -4,10 +4,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail_image_network/mocktail_image_network.dart';
 
 void main() {
-  testWidgets('can use mocktail for network images', (tester) async {
+  testWidgets('Client will return with a valid image', (tester) async {
     await mockNetworkImages(() async {
       await tester.pumpWidget(FakeApp());
-      expect(find.byType(Image), findsOneWidget);
+      var image = find.image(const NetworkImage(kImageUrl));
+      expect(image, findsOneWidget);
+      await tester.pump();
+      expect(image, findsOneWidget);
     });
   });
+
+  testWidgets(
+    'Client will return with failure and error widget will be shown',
+    (tester) async {
+      await tester.pumpWidget(FakeApp());
+      expect(find.image(const NetworkImage(kImageUrl)), findsOneWidget);
+      await tester.pump();
+      expect(find.text(kErrorText), findsOneWidget);
+    },
+  );
 }

--- a/packages/mocktail_image_network/pubspec.yaml
+++ b/packages/mocktail_image_network/pubspec.yaml
@@ -9,6 +9,11 @@ environment:
 
 dependencies:
   mocktail: ^0.3.0
+  flutter:
+    sdk: flutter
+  flutter_test:
+    sdk: flutter
 
 dev_dependencies:
   test: ^1.16.0
+

--- a/packages/mocktail_image_network/test/mocktail_image_network_test.dart
+++ b/packages/mocktail_image_network/test/mocktail_image_network_test.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:mocktail_image_network/mocktail_image_network.dart';
 import 'package:test/test.dart';
 
@@ -13,7 +13,8 @@ void main() {
           final expectedData = base64Decode(
             '''iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==''',
           );
-          final client = HttpClient()..autoUncompress = false;
+          final client = debugNetworkImageHttpClientProvider!()
+            ..autoUncompress = false;
           final request = await client.getUrl(Uri.https('', ''));
           final response = await request.close();
           final data = <int>[];
@@ -30,7 +31,8 @@ void main() {
 
     test('should properly pass through onDone', () async {
       await mockNetworkImages(() async {
-        final client = HttpClient()..autoUncompress = false;
+        final client = debugNetworkImageHttpClientProvider!()
+          ..autoUncompress = false;
         final request = await client.getUrl(Uri.https('', ''));
         final response = await request.close();
         var onDoneCalled = false;


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

YES

## Description

<!--- Describe your changes in detail -->

The implementation is dangers, because it will effect other tests in the test file.

For example the following app renders normally a network image and if there is an error, 
the error builder should be used.
```
/// Sample app used to showcase `mocktail_image_network`
class FakeApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        body: Center(
          child: Image.network(
            kImageUrl,
            errorBuilder: (
              context,
              error,
              stackTrace,
            ) {
              return const Text(kErrorText);
            },
          ),
        ),
      ),
    );
  }
}

/// public image url for testing
const kImageUrl = 'https://randmom-uri.com';

/// public error text for testing
const kErrorText = 'You are Doomed!';
```

The following test should work:

```
void main() {
  testWidgets('Client will return with a valid image', (tester) async {
    await mockNetworkImages(() async {
      await tester.pumpWidget(FakeApp());
      var image = find.image(const NetworkImage(kImageUrl));
      expect(image, findsOneWidget);
      await tester.pump();
      expect(image, findsOneWidget);
    });
  });

  testWidgets(
    'Client will return with failure and error widget will be shown',
    (tester) async {
      await tester.pumpWidget(FakeApp());
      expect(find.image(const NetworkImage(kImageUrl)), findsOneWidget);
      await tester.pump();
      expect(find.text(kErrorText), findsOneWidget);
    },
  );
}
```
Unfortunately the don't because the client will be used again. 
So the result of the second test will be a failure because the error text does not exist. 

In the debug setting  is an other way described to do so:

```
/// Provider from which [NetworkImage] will get its [HttpClient] in debug builds.
///
/// If this value is unset, [NetworkImage] will use its own internally-managed
/// [HttpClient].
///
/// This setting can be overridden for testing to ensure that each test receives
/// a mock client that hasn't been affected by other tests.
///
/// This value is ignored in non-debug builds.
HttpClientProvider? debugNetworkImageHttpClientProvider;
```
So I adjusted the code accordingly.

Still there is some issue, because already cached network images, will still be available. 
So I added the functionality to also delete the cache. 



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-  ❌ Breaking change (fix or feature that would cause existing functionality to change)

