### PR TITLE
docs(mocktail): update `verify` example in `README.md`

### DIFF
--- a/packages/mocktail/README.md
+++ b/packages/mocktail/README.md
@@ -49,13 +49,13 @@ cat.sound();
 // Verify the interaction occurred.
 verify(() => cat.sound()).called(1);
 
-// When mocktail verifies a method call, said call is then excluded from further verifications.
+// When mocktail verifies an invocation, it is then excluded from further verifications.
 verifyNever(() => cat.sound());
 
 // Interact with the mock instance again.
 cat.sound();
 
-// The interaction count is now one again and not two.
+// The verification count is 1 since there was only 1 invocation since the last verification.
 verify(() => cat.sound()).called(1);
 ```
 

--- a/packages/mocktail/README.md
+++ b/packages/mocktail/README.md
@@ -49,11 +49,14 @@ cat.sound();
 // Verify the interaction occurred.
 verify(() => cat.sound()).called(1);
 
+// When mocktail verifies a method call, said call is then excluded from further verifications.
+verifyNever(() => cat.sound());
+
 // Interact with the mock instance again.
 cat.sound();
 
-// Verify the interaction occurred twice.
-verify(() => cat.sound()).called(2);
+// The interaction count is now one again and not two.
+verify(() => cat.sound()).called(1);
 ```
 
 ## Additional Usage


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description
When you simply copy & paste the example of [Stub and Verify Behavior](https://github.com/felangel/mocktail/tree/main/packages/mocktail#stub-and-verify-behavior) into a test it fails.
We stumbled upon it, when actually trying to verify multiple calls and were wondering why the count is off, especially after looking at the example.
Maybe this helps better in understanding how it works?

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
