### PR TITLE
feat(mocktail_image_network): add ability to mock images by url

### DIFF
--- a/packages/mocktail_image_network/lib/src/mocktail_image_network.dart
+++ b/packages/mocktail_image_network/lib/src/mocktail_image_network.dart
@@ -5,8 +5,8 @@ import 'dart:typed_data';
 
 import 'package:mocktail/mocktail.dart';
 
-/// Signature for a function that returns a [List<int>] for a given [Uri].
-typedef ImageMockProvider = List<int> Function(Uri uri);
+/// Signature for a function that returns a `List<int>` for a given [Uri].
+typedef ImageResolver = List<int> Function(Uri uri);
 
 /// {@template mocktail_image_network}
 /// Utility method that allows you to execute a widget test when you pump a
@@ -47,16 +47,17 @@ typedef ImageMockProvider = List<int> Function(Uri uri);
 T mockNetworkImages<T>(
   T Function() body, {
   Uint8List? imageBytes,
-  ImageMockProvider? imageMockProvider,
+  ImageResolver? imageResolver,
 }) {
   assert(
-    imageBytes == null || imageMockProvider == null,
-    'You can only provide one of imageBytes or provider',
+    imageBytes == null || imageResolver == null,
+    'One of imageBytes or imageResolver can be provided, but not both.',
   );
-  imageMockProvider ??= _defaultMockProviderFor(imageBytes);
   return HttpOverrides.runZoned(
     body,
-    createHttpClient: (_) => _createHttpClient(imageMockProvider!),
+    createHttpClient: (_) => _createHttpClient(
+      imageResolver ??= _defaultImageResolver(imageBytes),
+    ),
   );
 }
 
@@ -74,36 +75,30 @@ class _MockHttpClientResponse extends Mock implements HttpClientResponse {}
 
 class _MockHttpHeaders extends Mock implements HttpHeaders {}
 
-HttpClient _createHttpClient(ImageMockProvider mockProvider) {
+HttpClient _createHttpClient(ImageResolver imageResolver) {
   final client = _MockHttpClient();
 
   when(() => client.getUrl(any())).thenAnswer(
     (invokation) async => _createRequest(
       invokation.positionalArguments.first as Uri,
-      mockProvider,
+      imageResolver,
     ),
   );
   when(() => client.openUrl(any(), any())).thenAnswer(
     (invokation) async => _createRequest(
       invokation.positionalArguments.last as Uri,
-      mockProvider,
+      imageResolver,
     ),
   );
 
   return client;
 }
 
-HttpClientRequest _createRequest(
-  Uri uri,
-  ImageMockProvider mockProvider,
-) {
+HttpClientRequest _createRequest(Uri uri, ImageResolver imageResolver) {
   final request = _MockHttpClientRequest();
   final headers = _MockHttpHeaders();
 
   when(() => request.headers).thenReturn(headers);
-  when(request.close).thenAnswer(
-    (invokation) async => _createResponseForUri(uri, mockProvider),
-  );
   when(
     () => request.addStream(any()),
   ).thenAnswer((invocation) {
@@ -113,29 +108,31 @@ HttpClientRequest _createRequest(
       (previous, element) => previous..addAll(element),
     );
   });
+  when(
+    request.close,
+  ).thenAnswer((_) async => _createResponse(uri, imageResolver));
 
   return request;
 }
 
-HttpClientResponse _createResponseForUri(
-  Uri uri,
-  ImageMockProvider mockProvider,
-) {
+HttpClientResponse _createResponse(Uri uri, ImageResolver imageResolver) {
   final response = _MockHttpClientResponse();
   final headers = _MockHttpHeaders();
-
-  final data = mockProvider(uri);
+  final data = imageResolver(uri);
 
   when(() => response.headers).thenReturn(headers);
   when(() => response.contentLength).thenReturn(data.length);
   when(() => response.statusCode).thenReturn(HttpStatus.ok);
   when(() => response.isRedirect).thenReturn(false);
+  when(() => response.redirects).thenReturn([]);
   when(() => response.persistentConnection).thenReturn(false);
   when(() => response.reasonPhrase).thenReturn('OK');
-  when(() => response.compressionState)
-      .thenReturn(HttpClientResponseCompressionState.notCompressed);
-  when(() => response.handleError(any(), test: any(named: 'test')))
-      .thenAnswer((invocation) => Stream<List<int>>.value(data));
+  when(
+    () => response.compressionState,
+  ).thenReturn(HttpClientResponseCompressionState.notCompressed);
+  when(
+    () => response.handleError(any(), test: any(named: 'test')),
+  ).thenAnswer((_) => Stream<List<int>>.value(data));
   when(
     () => response.listen(
       any(),
@@ -145,15 +142,16 @@ HttpClientResponse _createResponseForUri(
     ),
   ).thenAnswer((invocation) {
     final onData =
-        invocation.positionalArguments[0] as void Function(List<int>);
+        invocation.positionalArguments.first as void Function(List<int>);
     final onDone = invocation.namedArguments[#onDone] as void Function()?;
-    return Stream<List<int>>.fromIterable(<List<int>>[data])
-        .listen(onData, onDone: onDone);
+    return Stream<List<int>>.fromIterable(
+      <List<int>>[data],
+    ).listen(onData, onDone: onDone);
   });
   return response;
 }
 
-ImageMockProvider _defaultMockProviderFor(Uint8List? imageBytes) {
+ImageResolver _defaultImageResolver(Uint8List? imageBytes) {
   if (imageBytes != null) return (_) => imageBytes;
 
   return (uri) {
@@ -164,9 +162,10 @@ ImageMockProvider _defaultMockProviderFor(Uint8List? imageBytes) {
 
 final _mockedResponses = <String, List<int>>{
   'png': _transparentPixelPng,
-  'svg': '<svg viewBox="0 0 100 100" />'.codeUnits,
+  'svg': _emptySvg,
 };
 
+final _emptySvg = '<svg viewBox="0 0 10 10" />'.codeUnits;
 final _transparentPixelPng = base64Decode(
   '''iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==''',
 );

--- a/packages/mocktail_image_network/lib/src/mocktail_image_network.dart
+++ b/packages/mocktail_image_network/lib/src/mocktail_image_network.dart
@@ -4,6 +4,9 @@ import 'dart:typed_data';
 
 import 'package:mocktail/mocktail.dart';
 
+/// Signature for a function that returns a [Uint8List] for a given [Uri].
+typedef ImageMockProvider = Uint8List Function(Uri uri);
+
 /// {@template mocktail_image_network}
 /// Utility method that allows you to execute a widget test when you pump a
 /// widget that contains an `Image.network` node in its tree.
@@ -41,11 +44,20 @@ import 'package:mocktail/mocktail.dart';
 /// ```
 /// {@endtemplate}
 T mockNetworkImages<T>(T Function() body, {Uint8List? imageBytes}) {
+  return mockNetworkImagesWith(
+    body,
+    provider: (uri) => imageBytes ?? _defaultMockProvider(uri),
+  );
+}
+
+/// {@macro mocktail_image_network}
+T mockNetworkImagesWith<T>(
+  T Function() body, {
+  ImageMockProvider provider = _defaultMockProvider,
+}) {
   return HttpOverrides.runZoned(
     body,
-    createHttpClient: (_) => _createHttpClient(
-      data: imageBytes ?? _transparentPixelPng,
-    ),
+    createHttpClient: (_) => _createHttpClient(provider),
   );
 }
 
@@ -62,14 +74,43 @@ class _MockHttpClientResponse extends Mock implements HttpClientResponse {}
 
 class _MockHttpHeaders extends Mock implements HttpHeaders {}
 
-HttpClient _createHttpClient({required List<int> data}) {
+HttpClient _createHttpClient(ImageMockProvider mockProvider) {
   final client = _MockHttpClient();
+  when(() => client.getUrl(any())).thenAnswer(
+    (invokation) async => _createRequest(
+      invokation.positionalArguments.first as Uri,
+      mockProvider,
+    ),
+  );
+  return client;
+}
+
+HttpClientRequest _createRequest(
+  Uri uri,
+  ImageMockProvider mockProvider,
+) {
   final request = _MockHttpClientRequest();
+  final headers = _MockHttpHeaders();
+  when(() => request.headers).thenReturn(headers);
+  when(request.close).thenAnswer(
+    (invokation) async => _createResponseForUri(uri, mockProvider),
+  );
+
+  return request;
+}
+
+HttpClientResponse _createResponseForUri(
+  Uri uri,
+  ImageMockProvider mockProvider,
+) {
   final response = _MockHttpClientResponse();
   final headers = _MockHttpHeaders();
+
+  final data = mockProvider(uri);
+
   when(() => response.compressionState)
       .thenReturn(HttpClientResponseCompressionState.notCompressed);
-  when(() => response.contentLength).thenReturn(_transparentPixelPng.length);
+  when(() => response.contentLength).thenReturn(data.length);
   when(() => response.statusCode).thenReturn(HttpStatus.ok);
   when(
     () => response.listen(
@@ -85,11 +126,22 @@ HttpClient _createHttpClient({required List<int> data}) {
     return Stream<List<int>>.fromIterable(<List<int>>[data])
         .listen(onData, onDone: onDone);
   });
-  when(() => request.headers).thenReturn(headers);
-  when(request.close).thenAnswer((_) async => response);
-  when(() => client.getUrl(any())).thenAnswer((_) async => request);
-  return client;
+  when(() => response.headers).thenReturn(headers);
+
+  return response;
 }
+
+Uint8List _defaultMockProvider(Uri uri) {
+  final extension = uri.path.split('.').last;
+  return _mockedResponses[extension] ?? _transparentPixelPng;
+}
+
+final _mockedResponses = <String, Uint8List>{
+  'png': _transparentPixelPng,
+  'svg': base64Decode(
+    '''PHN2ZyB3aWR0aD0nMTAwJyBoZWlnaHQ9JzEwMCcgdmlld0JveD0nMCAwIDEgMCAxMDAnIC8+''',
+  ),
+};
 
 final _transparentPixelPng = base64Decode(
   '''iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==''',

--- a/packages/mocktail_image_network/test/mocktail_image_network_test.dart
+++ b/packages/mocktail_image_network/test/mocktail_image_network_test.dart
@@ -73,7 +73,9 @@ void main() {
         await mockNetworkImages(() async {
           final expectedData = '<svg viewBox="0 0 100 100" />'.codeUnits;
           final client = HttpClient()..autoUncompress = false;
-          final request = await client.getUrl(Uri.https('', '/image.svg'));
+          final request =
+              await client.openUrl('GET', Uri.https('', '/image.svg'));
+          await request.addStream(Stream.value(<int>[]));
           final response = await request.close();
           final data = <int>[];
 

--- a/packages/mocktail_image_network/test/mocktail_image_network_test.dart
+++ b/packages/mocktail_image_network/test/mocktail_image_network_test.dart
@@ -71,9 +71,7 @@ void main() {
       'should properly mock svg response and complete without exceptions',
       () async {
         await mockNetworkImages(() async {
-          final expectedData = base64Decode(
-            '''PHN2ZyB3aWR0aD0nMTAwJyBoZWlnaHQ9JzEwMCcgdmlld0JveD0nMCAwIDEgMCAxMDAnIC8+''',
-          );
+          final expectedData = '<svg viewBox="0 0 100 100" />'.codeUnits;
           final client = HttpClient()..autoUncompress = false;
           final request = await client.getUrl(Uri.https('', '/image.svg'));
           final response = await request.close();
@@ -88,5 +86,28 @@ void main() {
         });
       },
     );
+
+    test('should properly use custom imageMockProvider', () async {
+      final bluePixel = base64Decode(
+        '''iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2NgYPj/HwADAgH/eL9GtQAAAABJRU5ErkJggg==''',
+      );
+
+      await mockNetworkImages(
+        () async {
+          final client = HttpClient()..autoUncompress = false;
+          final request = await client.getUrl(Uri.https(''));
+          final response = await request.close();
+          final data = <int>[];
+
+          response.listen(data.addAll);
+
+          // Wait for all microtasks to run
+          await Future<void>.delayed(Duration.zero);
+
+          expect(data, equals(bluePixel));
+        },
+        imageMockProvider: (uri) => bluePixel,
+      );
+    });
   });
 }

--- a/packages/mocktail_image_network/test/mocktail_image_network_test.dart
+++ b/packages/mocktail_image_network/test/mocktail_image_network_test.dart
@@ -66,5 +66,27 @@ void main() {
         imageBytes: greenPixel,
       );
     });
+
+    test(
+      'should properly mock svg response and complete without exceptions',
+      () async {
+        await mockNetworkImages(() async {
+          final expectedData = base64Decode(
+            '''PHN2ZyB3aWR0aD0nMTAwJyBoZWlnaHQ9JzEwMCcgdmlld0JveD0nMCAwIDEgMCAxMDAnIC8+''',
+          );
+          final client = HttpClient()..autoUncompress = false;
+          final request = await client.getUrl(Uri.https('', '/image.svg'));
+          final response = await request.close();
+          final data = <int>[];
+
+          response.listen(data.addAll);
+
+          // Wait for all microtasks to run
+          await Future<void>.delayed(Duration.zero);
+
+          expect(data, equals(expectedData));
+        });
+      },
+    );
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->

This Pull Request enhances the `mockNetworkImages` utility method by introducing an optional `imageMockProvider` parameter. This allows users to provide custom mock image data based on the URI. It refactors the `HttpClient` creation process to allow dynamic generation of mock responses based on requested URIs using this provider. Additionally, default mock data for SVG file type is provided.

Also, fix `flutter_svg` compatibility.

closes #239

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
