### PR TITLE
fix: handle null positional args before matchers

### DIFF
--- a/packages/mocktail/lib/src/_is_invocation.dart
+++ b/packages/mocktail/lib/src/_is_invocation.dart
@@ -227,14 +227,13 @@ class _InvocationForMatchedArguments extends Invocation {
 
   static List<dynamic> _reconstitutePositionalArgs(Invocation invocation) {
     final positionalArguments = <dynamic>[];
-    final nullPositionalArguments =
+    final matchedPositionalArguments =
         invocation.positionalArguments.where((dynamic arg) {
-      return arg == null ||
-          _storedArgs.any(
-            (storedArg) => storedArg._fallbackValue == arg,
-          );
+      return _storedArgs.any(
+        (storedArg) => storedArg._fallbackValue == arg,
+      );
     });
-    if (_storedArgs.length > nullPositionalArguments.length) {
+    if (_storedArgs.length > matchedPositionalArguments.length) {
       // More _positional_ ArgMatchers were stored than were actually passed as
       // positional arguments. There are three ways this call could have been
       // parsed and resolved:
@@ -265,8 +264,7 @@ class _InvocationForMatchedArguments extends Invocation {
       final arg = _storedArgs[storedIndex];
       final dynamic positionalArgument =
           invocation.positionalArguments[positionalIndex];
-      if (positionalArgument == null ||
-          positionalArgument == arg._fallbackValue) {
+      if (positionalArgument == arg._fallbackValue) {
         // Add the [ArgMatcher] given to the argument matching helper.
         positionalArguments.add(arg);
         storedIndex++;

--- a/packages/mocktail/test/mockito_compat/capture_test.dart
+++ b/packages/mocktail/test/mockito_compat/capture_test.dart
@@ -7,6 +7,8 @@ class _RealClass {
   String? methodWithNormalArgs(int? x) => 'Real';
   String? methodWithListArgs(List<int>? x) => 'Real';
   String? methodWithPositionalArgs(int? x, [int? y]) => 'Real';
+  String? methodWithNullableAndNonNullablePositionalArgs(int? x, int y) =>
+      'Real';
   String? methodWithTwoNamedArgs(int? x, {int? y, int? z}) => 'Real';
   set setter(String? arg) {
     throw StateError('I must be mocked');
@@ -80,6 +82,19 @@ void main() {
             .captured,
         equals([1, null, 2, 3]),
       );
+    });
+
+    test('should capture matcher after null positional arg', () {
+      mock.methodWithNullableAndNonNullablePositionalArgs(null, 3);
+
+      final captured = verify(
+        () => mock.methodWithNullableAndNonNullablePositionalArgs(
+          null,
+          captureAny(),
+        ),
+      ).captured;
+
+      expect(captured, equals([3]));
     });
 
     test('should capture multiple invocations', () {

--- a/packages/mocktail/test/mockito_compat/verify_test.dart
+++ b/packages/mocktail/test/mockito_compat/verify_test.dart
@@ -12,6 +12,8 @@ class _RealClass {
   String? methodWithListArgs(List<int>? x) => 'Real';
   String? methodWithOptionalArg([int? x]) => 'Real';
   String? methodWithPositionalArgs(int? x, [int? y]) => 'Real';
+  String? methodWithNullableAndNonNullablePositionalArgs(int? x, int y) =>
+      'Real';
   String? methodWithNamedArgs(int x, {int? y}) => 'Real';
   String? methodWithOnlyNamedArgs({int? y = 0, int? z}) => 'Real';
   String? methodWithTypeArgs<T>(int? x) => 'Real';
@@ -98,6 +100,14 @@ void main() {
         verify(() => mock.methodWithPositionalArgs(42, 18));
       });
       verify(() => mock.methodWithPositionalArgs(42, 17));
+    });
+
+    test('should verify null positional arg followed by matcher', () {
+      mock.methodWithNullableAndNonNullablePositionalArgs(null, 3);
+
+      verify(
+        () => mock.methodWithNullableAndNonNullablePositionalArgs(null, any()),
+      ).called(1);
     });
 
     test('should mock method with named args', () {


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Fixes #256.

This fixes positional matcher reconstruction when a real nullable positional argument appears before an argument matcher.

Example:

    verify(() => mock.method(null, any()));

Previously, mocktail treated any positional `null` as a possible matcher placeholder. That caused the real `null` argument to be consumed as the matcher position, shifting the actual matcher and making verification or capture fail.

The change keeps the existing fallback-value reconstruction model, but removes the blanket `null` shortcut. Positional matchers are now reconstructed only when the invocation argument matches a stored matcher fallback value. This preserves literal `null` arguments as real arguments while still supporting `any()` and `captureAny()`.

Added regression coverage for:

- verifying `null` followed by `any()`
- capturing an argument after a literal `null` with `captureAny()`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore