### PR TITLE
docs: clarify async exception verification

### DIFF
--- a/packages/mocktail/README.md
+++ b/packages/mocktail/README.md
@@ -223,6 +223,25 @@ final person = MockPerson();
 when(() => person.sleep()).thenAnswer((_) async {});
 ```
 
+#### Why does `verify` fail after testing an async exception?
+
+[Relevant Issue](https://github.com/felangel/mocktail/issues/247)
+
+When testing an async exception, `expect()` registers the async matcher but does
+not wait before continuing. If you call `verify` immediately after it, the
+future may not have completed and not all mock invocations have happened yet.
+
+Use `expectLater` and await it before verifying:
+
+```dart
+await expectLater(
+  () => remoteDataSource.getSomething(),
+  throwsA(isA<Exception>()),
+);
+
+verify(() => http.post(any())).called(1);
+```
+
 #### Why is my method throwing a `TypeError` when stubbing using `any()`?
 
 [Relevant Issue](https://github.com/felangel/mocktail/issues/162)

--- a/packages/mocktail/test/mocktail_test.dart
+++ b/packages/mocktail/test/mocktail_test.dart
@@ -128,6 +128,25 @@ void main() {
       verify(() => foo.asyncVoid()).called(1);
     });
 
+    test('verify after awaited async throwsA expectation', () async {
+      final exception = Exception('oops');
+      when(() => foo.asyncValueWithPositionalArg(1)).thenAnswer((_) async => 1);
+      when(() => foo.asyncValueWithPositionalArg(2)).thenAnswer((_) async => 2);
+      when(() => foo.asyncValueWithPositionalArg(3)).thenThrow(exception);
+
+      Future<void> callAsyncValues() async {
+        await foo.asyncValueWithPositionalArg(1);
+        await foo.asyncValueWithPositionalArg(2);
+        await foo.asyncValueWithPositionalArg(3);
+      }
+
+      await expectLater(callAsyncValues(), throwsA(exception));
+
+      verify(() => foo.asyncValueWithPositionalArg(1)).called(1);
+      verify(() => foo.asyncValueWithPositionalArg(2)).called(1);
+      verify(() => foo.asyncValueWithPositionalArg(3)).called(1);
+    });
+
     test('when asyncValueWithPositionalArg (any)', () async {
       when(() => foo.asyncValueWithPositionalArg(any())).thenAnswer(
         (_) async => 10,


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Addresses #247.

This documents the async timing behavior when `throwsA` is used with a `Future` or a closure returning a `Future`, and adds regression coverage for verifying mock interactions after the async exception expectation has been awaited.

`expect(..., throwsA(...))` registers the async matcher but does not wait before the next statement runs. In the issue reproduction, the code under test yields after the first `await`, so immediate `verify` calls can run before later mocked calls have happened.

The documented pattern is to use `await expectLater(...)` before verifying interactions.

Added regression coverage showing that after `await expectLater(...)`, all calls made before the thrown async exception remain verifiable.

Verification:

- `git diff --check`
- `fvm dart analyze`
- `fvm dart test`
- `fvm dart test --coverage=coverage`
- `fvm dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=lib`
- coverage remains `430/430 = 100.00%`

## Type of Change

- [ ] ✨ New feature
- [ ] 🛠️ Bug fix
- [ ] ❌ Breaking change
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore