### PR TITLE
fix(mocktail): hint when previous when() is missing then*

### DIFF
--- a/packages/mocktail/lib/src/mocktail.dart
+++ b/packages/mocktail/lib/src/mocktail.dart
@@ -203,7 +203,11 @@ typedef _ReturnsCannedResponse = Expectation<dynamic> Function();
 /// See the README for more information.
 When<T> Function<T>(T Function() x) get when {
   if (_whenCall != null) {
-    throw StateError('Cannot call `when` within a stub response');
+    throw StateError(
+      'Cannot call `when` within a stub response. '
+      'If this is unexpected, complete the previous `when` with '
+      '`thenReturn`, `thenAnswer`, or `thenThrow`.',
+    );
   }
   _whenInProgress = true;
   return <T>(T Function() fn) {

--- a/packages/mocktail/test/mocktail_test.dart
+++ b/packages/mocktail/test/mocktail_test.dart
@@ -370,6 +370,24 @@ void main() {
       verify(() => foo.voidFunction()).called(1);
     });
 
+    test('when without then* reports incomplete stub on next when', () {
+      when(() => foo.voidFunction());
+      expect(
+        () => when(() => foo.intValue).thenReturn(10),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            allOf(
+              contains('thenReturn'),
+              contains('thenAnswer'),
+              contains('thenThrow'),
+            ),
+          ),
+        ),
+      );
+    });
+
     test('when voidWithPositionalAndOptionalNamedArg (default)', () {
       when(
         () => foo.voidWithPositionalAndOptionalNamedArg(10),


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Fixes #213.

`when(() => mock.voidMethod())` without `thenReturn`/`thenAnswer`/`thenThrow` leaves `_whenCall` set. The next `when` then fails with:

```
Bad state: Cannot call `when` within a stub response
```

That's usually wrong — nothing is stubbing, the previous `when` just never got a `then*`. Same thing happens if `thenReturn(...)` throws while building its argument.

I left void-method stubbing alone and only added a hint on that error.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Testing

- Added `when without then* reports incomplete stub on next when`
- `dart test` — 221 passing
- `dart analyze --fatal-infos` — clean
