### PR TITLE
fix(mocktail): name the verified mock on call-count mismatch

### DIFF
--- a/packages/mocktail/lib/src/mocktail.dart
+++ b/packages/mocktail/lib/src/mocktail.dart
@@ -512,9 +512,11 @@ Verify _makeVerify(bool never) {
     _verificationInProgress = false;
     if (_verifyCalls.length == 1) {
       final verifyCall = _verifyCalls.removeLast();
+      final member = _symbolToString(verifyCall.verifyInvocation.memberName);
       final result = VerificationResult._(
         verifyCall.matchingInvocations.length,
         verifyCall.matchingCapturedArgs,
+        verifiedCall: '${verifyCall.mock.runtimeType}.$member',
       );
       verifyCall._checkWith(never);
       return result;
@@ -536,9 +538,14 @@ typedef Verify = VerificationResult Function<T>(
 /// * verifying call count, via [called],
 /// * collecting captured arguments, via [captured].
 class VerificationResult {
-  VerificationResult._(this.callCount, this._captured);
+  VerificationResult._(
+    this.callCount,
+    this._captured, {
+    String? verifiedCall,
+  }) : _verifiedCall = verifiedCall;
 
   final List<dynamic> _captured;
+  final String? _verifiedCall;
 
   /// List of all arguments captured in real calls.
   ///
@@ -592,10 +599,13 @@ class VerificationResult {
   ///
   /// To assert that a method was called zero times, use [verifyNever].
   void called(dynamic matcher) {
+    final target = _verifiedCall;
     expect(
       callCount,
       wrapMatcher(matcher),
-      reason: 'Unexpected number of calls',
+      reason: target == null
+          ? 'Unexpected number of calls'
+          : 'Unexpected number of calls of $target',
     );
   }
 }

--- a/packages/mocktail/test/mockito_compat/verify_test.dart
+++ b/packages/mocktail/test/mockito_compat/verify_test.dart
@@ -372,7 +372,9 @@ void main() {
         mock
           ..methodWithoutArgs()
           ..methodWithoutArgs();
-        expectFail('Expected: <1>\n  Actual: <2>\nUnexpected number of calls\n',
+        expectFail(
+            'Expected: <1>\n  Actual: <2>\n'
+            'Unexpected number of calls of _MockedClass.methodWithoutArgs\n',
             () {
           verify(() => mock.methodWithoutArgs()).called(1);
         });
@@ -394,7 +396,8 @@ void main() {
             'Expected: a value greater than <2>\n'
             '  Actual: <1>\n'
             '   Which: is not a value greater than <2>\n'
-            'Unexpected number of calls\n', () {
+            'Unexpected number of calls of _MockedClass.methodWithoutArgs\n',
+            () {
           verify(() => mock.methodWithoutArgs()).called(greaterThan(2));
         });
       });
@@ -422,7 +425,8 @@ void main() {
         expectFail(
             'Expected: <0>\n'
             '  Actual: <1>\n'
-            'Unexpected number of calls\n', () {
+            'Unexpected number of calls of _MockedClass.methodWithoutArgs\n',
+            () {
           verify(() => mock.methodWithoutArgs()).called(0);
         });
       });

--- a/packages/mocktail/test/mocktail_test.dart
+++ b/packages/mocktail/test/mocktail_test.dart
@@ -75,6 +75,18 @@ class MockBaz<T> extends Mock implements Baz<T> {
 
 class MockInvocation extends Mock implements Invocation {}
 
+class DataProvider {
+  String getValue() => 'value';
+}
+
+class ActionSink {
+  void doSomethingImportant(String value) {}
+}
+
+class MockDataProvider extends Mock implements DataProvider {}
+
+class MockActionSink extends Mock implements ActionSink {}
+
 void main() {
   group('Foo', () {
     late Foo foo;
@@ -672,6 +684,46 @@ void main() {
         expectation.toString(),
         equals('$Expectation {$call -> $response}'),
       );
+    });
+  });
+
+  group('verify with a second mock in the callback', () {
+    late MockDataProvider provider;
+    late MockActionSink sink;
+
+    setUp(() {
+      provider = MockDataProvider();
+      sink = MockActionSink();
+    });
+
+    tearDown(resetMocktailState);
+
+    test('call count error names the mock that was actually verified', () {
+      when(() => provider.getValue()).thenReturn('mock value');
+      for (var i = 0; i < 5; i++) {
+        provider.getValue();
+      }
+      sink.doSomethingImportant(provider.getValue());
+
+      expect(
+        () => verify(
+          () => sink.doSomethingImportant(provider.getValue()),
+        ).called(1),
+        throwsA(
+          isA<TestFailure>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('Unexpected number of calls'),
+              contains('MockDataProvider'),
+              contains('getValue'),
+              isNot(contains('doSomethingImportant')),
+            ),
+          ),
+        ),
+      );
+
+      verify(() => sink.doSomethingImportant('mock value')).called(1);
     });
   });
 }


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Fixes #179.

`verify(() => mockA.doIt(mockB.getValue()))` does not check `doIt`. `getValue()` has a non-nullable return, so the dummy `null` from verify throws a TypeError and the rest of the closure never runs. `.called(1)` then fails with Expected 1 / Actual 6 and never says which mock was counted.

I put the mock type and member on that error so it reads `Unexpected number of calls of MockDataProvider.getValue`.

The call you want is still `verify(() => mockA.doIt('mock value'))`.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Testing

- Added a regression test from the #179 snippet
- `dart test` — 221 passing
- `dart analyze --fatal-infos` — clean